### PR TITLE
handle both users with the 'player' and 'moderator' roles

### DIFF
--- a/server/workers/index.js
+++ b/server/workers/index.js
@@ -7,7 +7,7 @@ if (__DEVELOPMENT__) {
   require('dotenv').load()
 }
 
-require('./newPlayer').start()
+require('./newGameUser').start()
 require('./newChapter').start()
 require('./newOrUpdatedVote').start()
 require('./cycleLaunched').start()


### PR DESCRIPTION
**NOTE:** Must be merged in parallel with [idm/#80](https://github.com/LearnersGuild/idm/issues/80), as the queue name that connects the two services has been renamed.

Fixes #89

This worker now (somewhat) gracefully handles duplicate users in the queue. It
does a `.replace()` in RethinkDB rather than an `.insert()`. This doesn't
prevent the GitHub API call from getting executed multiple times, but the only
harm there is ... multiple invocations to the API that won't hurt anything
(from a data integrity perspective).
