### PR TITLE
if GitHub team already exists, fetch it

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "normalize.css": "^4.0.0",
     "normalizr": "^2.0.1",
     "optimize-css-assets-webpack-plugin": "^1.3.0",
+    "parse-link-header": "^0.4.1",
     "postcss": "^5.0.17",
     "postcss-modules-extract-imports": "^1.0.0",
     "postcss-modules-local-by-default": "^1.0.0",


### PR DESCRIPTION
Fixes #131

This should really only happen if a chapter with the same channelName gets created more than once. In reality, this should only happen when running the `npm run data:playtest` script.

We will inspect the response body that comes back from GitHub to see if it is this one particular error code. If it is, we'll call back out to GitHub to fetch the correct team with the same name (so that we can update the githubTeamId on the chapter).
