### PR TITLE
ensure that ChatClient doesn't return nested promise on error

### DIFF
--- a/server/clients/ChatClient.js
+++ b/server/clients/ChatClient.js
@@ -50,7 +50,7 @@ export default class ChatClient {
     return fetch(url, options)
       .then(resp => {
         if (!resp.ok) {
-          return Promise.reject(resp.json())
+          return resp.json().then(error => Promise.reject(error))
         }
         return resp.json()
       })

--- a/server/clients/__tests__/ChatClient.test.js
+++ b/server/clients/__tests__/ChatClient.test.js
@@ -101,7 +101,7 @@ describe(testContext(__filename), function () {
     it('throws an error if the channel does not exist', function () {
       return (
         expect(this.client.deleteChannel('non-existant-room'))
-          .to.eventually.be.rejected
+          .to.be.rejected
       )
     })
   })


### PR DESCRIPTION
Fixes #123

`resp.json()` returns a Promise that resolves to an object, not an object, so we'll call `.then()` on it first and then `Promise.reject`
