### PR TITLE
Improving notifications on cycle launch and reflection

### DIFF
--- a/server/workers/cycleLaunched.js
+++ b/server/workers/cycleLaunched.js
@@ -55,8 +55,10 @@ function getPlayerInfo(playerIds) {
 }
 
 function sendCycleLaunchAnnouncement(cycle, projects) {
-  const projectListString = projects.map(p => `#${p.name}`).join(', ')
-  const announcement = `🚀 The cycle has been launched and the following projects have been created: ${projectListString}`
+  const projectListString = projects.map(p => `#${p.name} - _${p.goal.title}_`).join('\n  • ')
+  const announcement = `🚀  *The cycle has been launched!*
+The following projects have been created:
+  • ${projectListString}`
   const client = new ChatClient()
 
   return r.table('chapters').get(cycle.chapterId).run()

--- a/server/workers/cycleReflectionStarted.js
+++ b/server/workers/cycleReflectionStarted.js
@@ -29,12 +29,13 @@ async function processRetrospectiveStarted(cycle) {
 }
 
 function sendRetroLaunchAnnouncement(cycle) {
-  const announcement = `🤔  Time to start your reflection process for cycle ${cycle.cycleNumber}!`
+  const announcement = `🤔  *Time to start your reflection process for cycle ${cycle.cycleNumber}*!\n`
+  const reflectionInstructions = 'To get started check out `/log --help` and `/review --help`'
 
   return r.table('chapters').get(cycle.chapterId).run()
     .then(chapter => Promise.all([
-      notifyChapterChannel(chapter, announcement),
-      notifyProjectChannels(chapter, announcement),
+      notifyChapterChannel(chapter, announcement + reflectionInstructions),
+      notifyProjectChannels(chapter, announcement + reflectionInstructions),
     ]))
 }
 

--- a/test/generatePlaytestData.js
+++ b/test/generatePlaytestData.js
@@ -28,6 +28,7 @@ function deleteProjects(chapterId) {
         const retroIds = project.cycleHistory.map(ch => ch.retrospectiveSurveyId)
         return reviewIds.concat(retroIds)
       }).reduce((result, ids) => result.concat(ids), [])
+        .filter(id => id)
 
       return Promise.all(deleteChannelPromises)
         // now delete the projects


### PR DESCRIPTION
- Projects listed with goal titles in the chapter room on launch

<img width="453" alt="_1__rocket_chat" src="https://cloud.githubusercontent.com/assets/189699/16641969/1f064740-43c3-11e6-80eb-54bda7905dd0.png">
- Brief instructions on logging reflections included in all channels when reflection begins.

<img width="501" alt="_1__rocket_chat 2" src="https://cloud.githubusercontent.com/assets/189699/16641956/0c1abc38-43c3-11e6-8429-48595f5376ac.png">

Also fixing a bug in the playtest script that caused errors when data
was reset before projects entered the reflection state and surveys were
created.

Fixes #232
