### PR TITLE
fix survey creation bug

### DIFF
--- a/server/actions/__tests__/createCycleReflectionSurveys.test.js
+++ b/server/actions/__tests__/createCycleReflectionSurveys.test.js
@@ -5,7 +5,7 @@
 import r from '../../../db/connect'
 import factory from '../../../test/factories'
 import {withDBCleanup, expectSetEquality} from '../../../test/helpers'
-import {projectsTable, getTeamPlayerIds, getProjectHistoryForCycle} from '../../../server/db/project'
+import {projectsTable, getProjectById, getTeamPlayerIds, getProjectHistoryForCycle} from '../../../server/db/project'
 import {PROJECT_REVIEW_DESCRIPTOR, RETROSPECTIVE_DESCRIPTOR} from '../../../common/models/surveyBlueprint'
 
 import {
@@ -78,6 +78,20 @@ describe(testContext(__filename), function () {
           createProjectReviewSurveys(this.cycle)
           .then(() => createProjectReviewSurveys(this.cycle))
         ).to.be.rejected
+      })
+
+      describe('when there are other projects not in this cycle', function () {
+        beforeEach(async function () {
+          this.projectFromAnotherCycle = await factory.create('project', {chapterId: this.cycle.chapterId})
+        })
+
+        it('ignores them', async function () {
+          const projectBefore = this.projectFromAnotherCycle
+          await createProjectReviewSurveys(this.cycle)
+          const projectAfter = await getProjectById(this.projectFromAnotherCycle.id)
+
+          expect(projectAfter).to.deep.eq(projectBefore)
+        })
       })
     })
 
@@ -162,6 +176,20 @@ describe(testContext(__filename), function () {
         } catch (e) {
           throw (e)
         }
+      })
+
+      describe('when there are other projects not in this cycle', function () {
+        beforeEach(async function () {
+          this.projectFromAnotherCycle = await factory.create('project', {chapterId: this.cycle.chapterId})
+        })
+
+        it('ignores them', async function () {
+          const projectBefore = this.projectFromAnotherCycle
+          await createRetrospectiveSurveys(this.cycle)
+          const projectAfter = await getProjectById(this.projectFromAnotherCycle.id)
+
+          expect(projectAfter).to.deep.eq(projectBefore)
+        })
       })
 
       it('fails if called multiple times', function () {

--- a/server/actions/createCycleReflectionSurveys.js
+++ b/server/actions/createCycleReflectionSurveys.js
@@ -3,7 +3,7 @@ import {PROJECT_REVIEW_DESCRIPTOR, RETROSPECTIVE_DESCRIPTOR} from '../../common/
 import {getActiveQuestionsByIds} from '../../server/db/question'
 import {
   getTeamPlayerIds,
-  getProjectsForChapter,
+  getProjectsForChapterInCycle,
   getProjectHistoryForCycle,
   setProjectReviewSurveyForCycle,
   setRetrospectiveSurveyForCycle,
@@ -18,7 +18,7 @@ export default function createCycleReflectionSurveys(cycle) {
 }
 
 export function createProjectReviewSurveys(cycle) {
-  return getProjectsForChapter(cycle.chapterId)
+  return getProjectsForChapterInCycle(cycle.chapterId, cycle.id)
     .then(projects => Promise.all(
       projects.map(project => buildSurvey(project, cycle.id, PROJECT_REVIEW_DESCRIPTOR)
         .then(surveyId => setProjectReviewSurveyForCycle(project.id, cycle.id, surveyId))
@@ -26,7 +26,7 @@ export function createProjectReviewSurveys(cycle) {
 }
 
 export function createRetrospectiveSurveys(cycle) {
-  return getProjectsForChapter(cycle.chapterId)
+  return getProjectsForChapterInCycle(cycle.chapterId, cycle.id)
     .then(projects => Promise.all(
       projects.map(project => buildSurvey(project, cycle.id, RETROSPECTIVE_DESCRIPTOR)
         .then(surveyId => setRetrospectiveSurveyForCycle(project.id, cycle.id, surveyId))

--- a/server/db/project.js
+++ b/server/db/project.js
@@ -17,7 +17,12 @@ export function getProjectByName(name) {
     .default(customQueryError('No project found with that name'))
 }
 
-export function getProjectsForChapter(chapterId) {
+export function getProjectsForChapterInCycle(chapterId, cycleId) {
+  return getProjectsForChapter(chapterId)
+    .filter(row => row('cycleHistory')('cycleId').contains(cycleId))
+}
+
+function getProjectsForChapter(chapterId) {
   return projectsTable.getAll(chapterId, {index: 'chapterId'})
 }
 

--- a/server/workers/cycleReflectionStarted.js
+++ b/server/workers/cycleReflectionStarted.js
@@ -2,7 +2,7 @@ import raven from 'raven'
 
 import {getQueue} from '../util'
 import ChatClient from '../../server/clients/ChatClient'
-import {getProjectsForChapter} from '../../server/db/project'
+import {getProjectsForChapterInCycle} from '../../server/db/project'
 import {parseQueryError} from '../../server/db/errors'
 import createCycleReflectionSurveys from '../../server/actions/createCycleReflectionSurveys'
 import reloadSurveyAndQuestionData from '../../server/actions/reloadSurveyAndQuestionData'
@@ -35,7 +35,7 @@ function sendRetroLaunchAnnouncement(cycle) {
   return r.table('chapters').get(cycle.chapterId).run()
     .then(chapter => Promise.all([
       notifyChapterChannel(chapter, announcement + reflectionInstructions),
-      notifyProjectChannels(chapter, announcement + reflectionInstructions),
+      notifyProjectChannels(cycle, announcement + reflectionInstructions),
     ]))
 }
 
@@ -52,9 +52,9 @@ function notifyChapterChannel(chapter, announcement) {
   return client.sendMessage(chapter.channelName, announcement)
 }
 
-function notifyProjectChannels(chapter, announcement) {
+function notifyProjectChannels(cycle, announcement) {
   const client = new ChatClient()
-  return getProjectsForChapter(chapter.id)
+  return getProjectsForChapterInCycle(cycle.chapterId, cycle.id)
     .then(projects => Promise.all(
       projects.map(project => client.sendMessage(project.name, announcement))
     ))


### PR DESCRIPTION
When creating surveys for a cycle we were pulling all projects for the
chapter, not just the ones active in this cycle, which was causing
errors. Once I looked into that I noticed that we were making a similar
mistake when notifying project rooms about the the starts of cycle
reflection, we should only notify projects for that cycle, not every
project that has ever been active in that chapter.
