### PR TITLE
better error handling for `/cycle reflect`

### DIFF
--- a/server/workers/cycleLaunched.js
+++ b/server/workers/cycleLaunched.js
@@ -19,7 +19,6 @@ export function start() {
       await processCycleLaunch(cycle)
       console.log(`Cycle ${cycle.id} successfully launched`)
     } catch (err) {
-      sentry.captureException(err)
       await _handleCycleLaunchError(cycle, err)
     }
   })
@@ -87,11 +86,9 @@ The following projects have been created:
 }
 
 async function _handleCycleLaunchError(cycle, err) {
+  sentry.captureException(err)
   err = parseQueryError(err)
-  console.error('Cycle launch error:', err)
-  if (process.env !== 'production') {
-    console.error(err.stack)
-  }
+  console.error('Cycle launch error:', err.stack)
 
   const socket = getSocket()
 

--- a/server/workers/cycleReflectionStarted.js
+++ b/server/workers/cycleReflectionStarted.js
@@ -17,7 +17,7 @@ export function start() {
     processRetrospectiveStarted(cycle)
       .catch(err => {
         sentry.captureException(err)
-        console.error('Uncaught Exception in cycleReflectionStarted worker!', err)
+        console.error('Uncaught Exception in cycleReflectionStarted worker!', err.stack)
       })
   )
 }
@@ -57,7 +57,7 @@ async function handleError(cycle, context, err) {
   err = parseQueryError(err)
   sentry.captureException(err)
   const errorMessage = `${context} - ${err}`
-  console.log(`Error: ${errorMessage}`)
+  console.error(`Error: ${errorMessage}`)
   await notifyModeratorsAboutError(cycle, errorMessage)
 }
 
@@ -65,7 +65,7 @@ async function notifyModeratorsAboutError(cycle, err) {
   try {
     await notifyModerators(cycle.chapterId, `❗️ **Error:** ${err}`)
   } catch (newErr) {
-    console.log(`Got this error [${newErr}] trying to notify moderators about this error [${err}]`)
+    console.error(`Got this error [${newErr}] trying to notify moderators about this error [${err}]`)
   }
 }
 


### PR DESCRIPTION
Errors now get sent to moderators AND sentry AND the logs with useful
context. Also sending `/cycle launch` errors to sentry and making sure
custom db errors get parsed. This of course still falls short of the
unified error handling architecture we want long term.

Fixes #280
