### PR TITLE
Move ecc calculation to cycle end. Also fix bug.

### DIFF
--- a/server/db/response.js
+++ b/server/db/response.js
@@ -22,11 +22,7 @@ export function getSurveyResponsesForPlayer(respondentId, surveyId, questionId, 
 }
 
 export function getSurveyResponses(surveyId, questionId) {
-  return responsesTable.between(
-    [questionId, r.minval, surveyId],
-    [questionId, r.maxval, surveyId],
-    {index: 'questionIdAndRespondentIdAndSurveyId'}
-  )
+  return responsesTable.filter({questionId, surveyId})
 }
 
 export async function saveResponsesForSurveyQuestion(newResponses) {

--- a/server/workers/cycleCompleted.js
+++ b/server/workers/cycleCompleted.js
@@ -1,15 +1,30 @@
 import {getQueue} from '../util'
 import ChatClient from '../../server/clients/ChatClient'
 import r from '../../db/connect'
+import {updateTeamECCStats} from '../../server/actions/updateTeamECCStats'
+import {getProjectsForChapterInCycle} from '../../server/db/project'
 
 export function start() {
   const cycleCompleted = getQueue('cycleCompleted')
-  cycleCompleted.process(({data: cycle}) => processCompletedCycle(cycle))
+  cycleCompleted.process(({data: cycle}) =>
+      processCompletedCycle(cycle)
+      .catch(err => console.error(`Error handling cycleCompleted event for ${cycle.id}:`, err))
+  )
 }
 
 export async function processCompletedCycle(cycle, chatClient = new ChatClient()) {
   console.log(`Completing cycle ${cycle.cycleNumber} of chapter ${cycle.chapterId}`)
+  await updateECC(cycle)
   await sendCompletionAnnouncement(cycle, chatClient)
+}
+
+function updateECC(cycle) {
+  return getProjectsForChapterInCycle(cycle.chapterId, cycle.id)
+    .then(projects =>
+      Promise.all(
+        projects.map(project => updateTeamECCStats(project, cycle.id))
+      )
+    )
 }
 
 function sendCompletionAnnouncement(cycle, chatClient) {

--- a/server/workers/surveyResponseSubmitted.js
+++ b/server/workers/surveyResponseSubmitted.js
@@ -5,7 +5,6 @@ import {getQueue} from '../util'
 import ChatClient from '../../server/clients/ChatClient'
 import {findProjectBySurveyId, getTeamPlayerIds} from '../../server/db/project'
 import {recordSurveyCompletedBy, surveyWasCompletedBy} from '../../server/db/survey'
-import {updateTeamECCStats} from '../../server/actions/updateTeamECCStats'
 
 const sentry = new raven.Client(process.env.SENTRY_SERVER_DSN)
 
@@ -49,14 +48,11 @@ export async function processSurveyResponseSubmitted(event, chatClient = new Cha
     if (changes.length > 0) {
       console.log(`Survey [${event.surveyId}] Completed By [${event.respondentId}]`)
       const handleSurveyComplete = {
-        retrospective: () => Promise.all([
-          announce(
-            [project.name],
-            buildRetroAnnouncement(project, cycleId, changes[0].new_val),
-            chatClient
-          ),
-          updateECCIfAllProjectRetroSurveysComplete(project, cycleId, changes[0].new_val)
-        ]),
+        retrospective: () => announce(
+          [project.name],
+          buildRetroAnnouncement(project, cycleId, changes[0].new_val),
+          chatClient
+        ),
         projectReview: () => announce(
           [project.name, chapter.channelName],
           buildProjectReviewAnnouncement(project, cycleId, changes[0].new_val),
@@ -92,14 +88,4 @@ function buildProjectReviewAnnouncement(project, cycleId, survey) {
 function announce(channels, announcement, chatClient) {
   const announcePromises = channels.map(channel => chatClient.sendMessage(channel, announcement))
   return Promise.all(announcePromises)
-}
-
-async function updateECCIfAllProjectRetroSurveysComplete(project, cycleId, updatedSurvey) {
-  const totalPlayers = getTeamPlayerIds(project, cycleId).length
-  const finishedPlayers = updatedSurvey.completedBy.length
-
-  if (finishedPlayers === totalPlayers) {
-    console.log(`All respondents have completed this survey [${updatedSurvey.id}]. Updating ECC.`)
-    await updateTeamECCStats(project, cycleId)
-  }
 }


### PR DESCRIPTION
Fixes #319

**The Bug:**

`getSurveyResponses` was using a compound index with min/max values for
the middle element. I think this had ended up pulling ALL of the
responses for that question, not just the ones for the survey we wanted.
I'm falling back to a simple filter for now. We can revisit the index
when performance becomes an issue.
