### PR TITLE
adding an hours question to the survey

### DIFF
--- a/common/models/survey.js
+++ b/common/models/survey.js
@@ -2,8 +2,9 @@ import micromustache from 'micromustache'
 
 export const QUESTION_SUBJECT_TYPES = {
   TEAM: 'team',
-  PLAYER: 'player', // TODO: should this just be SINGLE?
-  SINGLE: 'single',
+  PLAYER: 'player',
+  SINGLE: 'single', // TODO: this isn't really a subjectType =/
+  PROJECT: 'project',
 }
 
 export const QUESTION_RESPONSE_TYPES = {

--- a/common/util/survey.js
+++ b/common/util/survey.js
@@ -31,6 +31,7 @@ export function groupSurveyQuestions(questions) {
             })
             break
 
+          case QUESTION_SUBJECT_TYPES.PROJECT:
           case QUESTION_SUBJECT_TYPES.PLAYER:
             // group -> {subject: {}, questions: []}
             subject = question.subjects[0]
@@ -113,8 +114,20 @@ export function formFieldsForQuestionGroup(questionGroup) {
           const response = question.response && question.response.values ? question.response.values[0] : null
           const responseValue = response ? response.value : null
 
+          let title
+          switch (question.subjectType) {
+            case QUESTION_SUBJECT_TYPES.PLAYER:
+              title = `Feedback for @${subject.handle} (${subject.name})`
+              break
+            case QUESTION_SUBJECT_TYPES.PROJECT:
+              title = `#${subject.name}`
+              break
+            default:
+              title = subject.name
+          }
+
           const field = {
-            title: `Feedback for @${subject.handle} (${subject.name})`,
+            title,
             name: `${question.id}:${subject.id}`,
             label: question.body,
             hint: question.responseInstructions,

--- a/db/data/questions.yaml
+++ b/db/data/questions.yaml
@@ -54,3 +54,9 @@
   responseType: percentage
   subjectType: project
   active: true
+-
+  id: 29a4bc7e-631e-409b-a8ed-6d06a9ae39f7
+  body: How much time did you dedicate to this project?
+  responseType: text
+  subjectType: project
+  active: true

--- a/db/data/surveyBlueprints.yaml
+++ b/db/data/surveyBlueprints.yaml
@@ -20,6 +20,8 @@
       questionId: 26ccd2a0-64af-4bf4-ae6b-e87445a2b213
     -
       questionId: 60fb5922-6be7-4e76-aaa3-16d574489833
+    -
+      questionId: 29a4bc7e-631e-409b-a8ed-6d06a9ae39f7
 -
   id: 106c8683-4936-4c9b-b874-a70cfdd8ce20
   descriptor: projectReview

--- a/server/actions/__tests__/createCycleReflectionSurveys.test.js
+++ b/server/actions/__tests__/createCycleReflectionSurveys.test.js
@@ -123,7 +123,8 @@ describe(testContext(__filename), function () {
       beforeEach(async function() {
         this.teamQuestions = await factory.createMany('question', {subjectType: 'team'}, 2)
         this.playerQuestions = await factory.createMany('question', {subjectType: 'player'}, 2)
-        this.questions = this.teamQuestions.concat(this.playerQuestions)
+        this.projectQuestions = await factory.createMany('question', {responseType: 'integer', subjectType: 'project'}, 2)
+        this.questions = this.teamQuestions.concat(this.playerQuestions).concat(this.projectQuestions)
         this.surveyBlueprint = await factory.create('surveyBlueprint', {
           descriptor: RETROSPECTIVE_DESCRIPTOR,
           defaultQuestionRefs: this.questions.map(q => ({questionId: q.id}))

--- a/server/actions/createCycleReflectionSurveys.js
+++ b/server/actions/createCycleReflectionSurveys.js
@@ -100,6 +100,12 @@ const questionRefBuilders = {
           subjectIds: [playerId],
         }))
 
+      case 'project':
+        return [{
+          questionId: question.id,
+          subjectIds: [project.id],
+        }]
+
       default:
         throw new Error(`Unsupported default retrospective survey question type: ${question.subjectType} for question ${question.id}`)
     }

--- a/server/graphql/models/Survey/schema.js
+++ b/server/graphql/models/Survey/schema.js
@@ -11,6 +11,7 @@ export const SubjectTypeEnum = new GraphQLEnumType({
   values: {
     team: {description: 'A multipart subject requiring responses about each member of a project team'},
     player: {description: 'A player in the game'},
+    project: {description: 'A project'},
   }
 })
 


### PR DESCRIPTION
It occured to me that the "how many hours" question could be implemented
as a question about the project, not about the respondent. This turned
out be be pretty simple. Since we don't have integer questions yet I
just made it a text response. We can change that as soon as the UI
supports numeric inputs.

We still need to change how we do surveys to support self questions and
delivering different questions to different users, but this will allow
us to start collecting data.

Fixes: #345 
Fixes: #346
