### PR TITLE
Store additional player project stats

### DIFF
--- a/db/migrations/20160804151238-responsesIndexSurveyId.js
+++ b/db/migrations/20160804151238-responsesIndexSurveyId.js
@@ -1,0 +1,11 @@
+exports.up = function (r, conn) {
+  return r.table('responses')
+    .indexCreate('surveyId')
+    .run(conn)
+}
+
+exports.down = function (r, conn) {
+  return r.table('responses')
+    .indexDrop('surveyId')
+    .run(conn)
+}

--- a/server/db/__tests__/player.test.js
+++ b/server/db/__tests__/player.test.js
@@ -99,7 +99,7 @@ describe(testContext(__filename), function () {
       this.fetchPlayer = () => getPlayerById(this.player.id)
     })
 
-    it('creates the ecc attribute if missing', async function() {
+    it('creates the stats.ecc attribute if missing', async function() {
       await getPlayerById(this.player.id).replace(p => p.without('stats'))
       await savePlayerProjectStats(this.player.id, this.projectIds[0], this.cycleIds[0], {ecc: 40, abc: 4, rc: 10})
 
@@ -108,7 +108,7 @@ describe(testContext(__filename), function () {
       expect(player.stats.ecc).to.eq(40)
     })
 
-    it('adds to the existing cumulative ECC', async function() {
+    it('adds to the existing cumulative stats.ecc', async function() {
       expect(this.player).to.have.deep.property('stats.ecc')
 
       await getPlayerById(this.player.id).update({stats: {ecc: 10}})
@@ -122,15 +122,15 @@ describe(testContext(__filename), function () {
     it('creates the stats.projects attribute if neccessary', async function () {
       expect(this.player).to.not.have.deep.property('stats.projects')
 
-      const stats = {ecc: 20, abc: 4, rc: 5}
-      await savePlayerProjectStats(this.player.id, this.projectIds[0], this.cycleIds[0], stats)
+      const projectCycleStats = {ecc: 20, abc: 4, rc: 5, ec: 10, ecd: 20, ls: 80, cc: 85, hours: 30}
+      await savePlayerProjectStats(this.player.id, this.projectIds[0], this.cycleIds[0], projectCycleStats)
 
       const player = await this.fetchPlayer()
 
       expect(player.stats.ecc).to.eq(20)
       expect(player.stats.projects).to.deep.eq({
         [this.projectIds[0]]: {
-          cycles: {[this.cycleIds[0]]: stats}
+          cycles: {[this.cycleIds[0]]: projectCycleStats}
         },
       })
     })
@@ -138,22 +138,22 @@ describe(testContext(__filename), function () {
     it('adds a project entry to the stats if neccessary', async function () {
       expect(this.player).to.not.have.deep.property('stats.projects')
 
-      const stats = [
+      const projectCycleStats = [
         {ecc: 20, abc: 4, rc: 5},
         {ecc: 18, abc: 3, rc: 6},
       ]
-      await savePlayerProjectStats(this.player.id, this.projectIds[0], this.cycleIds[0], stats[0])
-      await savePlayerProjectStats(this.player.id, this.projectIds[1], this.cycleIds[1], stats[1])
+      await savePlayerProjectStats(this.player.id, this.projectIds[0], this.cycleIds[0], projectCycleStats[0])
+      await savePlayerProjectStats(this.player.id, this.projectIds[1], this.cycleIds[1], projectCycleStats[1])
 
       const player = await this.fetchPlayer()
 
       expect(player.stats.ecc).to.eq(38)
       expect(player.stats.projects).to.deep.eq({
         [this.projectIds[0]]: {
-          cycles: {[this.cycleIds[0]]: stats[0]}
+          cycles: {[this.cycleIds[0]]: projectCycleStats[0]}
         },
         [this.projectIds[1]]: {
-          cycles: {[this.cycleIds[1]]: stats[1]}
+          cycles: {[this.cycleIds[1]]: projectCycleStats[1]}
         },
       })
     })
@@ -161,12 +161,12 @@ describe(testContext(__filename), function () {
     it('adds a cycle entry to the project stats if needed', async function () {
       expect(this.player).to.not.have.deep.property('stats.projects')
 
-      const stats = [
+      const projectCycleStats = [
         {ecc: 20, abc: 4, rc: 5},
         {ecc: 18, abc: 3, rc: 6},
       ]
-      await savePlayerProjectStats(this.player.id, this.projectIds[0], this.cycleIds[0], stats[0])
-      await savePlayerProjectStats(this.player.id, this.projectIds[0], this.cycleIds[1], stats[1])
+      await savePlayerProjectStats(this.player.id, this.projectIds[0], this.cycleIds[0], projectCycleStats[0])
+      await savePlayerProjectStats(this.player.id, this.projectIds[0], this.cycleIds[1], projectCycleStats[1])
 
       const player = await this.fetchPlayer()
 
@@ -174,8 +174,8 @@ describe(testContext(__filename), function () {
       expect(player.stats.projects).to.deep.eq({
         [this.projectIds[0]]: {
           cycles: {
-            [this.cycleIds[0]]: stats[0],
-            [this.cycleIds[1]]: stats[1],
+            [this.cycleIds[0]]: projectCycleStats[0],
+            [this.cycleIds[1]]: projectCycleStats[1],
           },
         },
       })

--- a/server/db/question.js
+++ b/server/db/question.js
@@ -11,6 +11,10 @@ export function getActiveQuestionsByIds(ids) {
   return questionsTable.getAll(...ids).filter({active: true})
 }
 
+export function findQuestionsByIds(ids) {
+  return questionsTable.getAll(...ids)
+}
+
 export function saveQuestions(questions, options) {
   return Promise.all(questions.map(question =>
     replaceInTable(question, questionsTable, options)

--- a/server/db/response.js
+++ b/server/db/response.js
@@ -7,6 +7,10 @@ export function getResponseById(id) {
   return responsesTable.get(id)
 }
 
+export function findResponsesBySurveyId(surveyId) {
+  return responsesTable.getAll(surveyId, {index: 'surveyId'})
+}
+
 export function getSurveyResponsesForPlayer(respondentId, surveyId, questionId, subjectIds) {
   const responseExpr = responsesTable.getAll([
     questionId,

--- a/server/util/__tests__/stats.test.js
+++ b/server/util/__tests__/stats.test.js
@@ -1,0 +1,107 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+import {
+  aggregateBuildCycles,
+  relativeContribution,
+  expectedContribution,
+  expectedContributionDelta,
+  effectiveContributionCycles,
+  learningSupport,
+  cultureContrbution,
+} from '../stats'
+
+describe(testContext(__filename), function () {
+  describe('aggregateBuildCycles()', function () {
+    it('default build cycles (1)', function () {
+      const numPlayers = 4
+      const abc = aggregateBuildCycles(numPlayers)
+      expect(abc).to.eq(4)
+    })
+
+    it('build cycles > 1', function () {
+      const numPlayers = 4
+      const numBuildCycles = 3
+      const abc = aggregateBuildCycles(numPlayers, numBuildCycles)
+      expect(abc).to.eq(12)
+    })
+  })
+
+  describe('relativeContribution()', function () {
+    it('even', function () {
+      const rc = relativeContribution([10, 20, 20, 30])
+      expect(rc).to.eq(20)
+    })
+
+    it('round up', function () {
+      const rc = relativeContribution([10, 10, 21, 21])
+      expect(rc).to.eq(16)
+    })
+
+    it('round down', function () {
+      const rc = relativeContribution([10, 10, 21, 20])
+      expect(rc).to.eq(15)
+    })
+  })
+
+  describe('expectedContribution()', function () {
+    const playerHours = 20
+    const teamHours = 100
+    const ec = expectedContribution(playerHours, teamHours)
+    expect(ec).to.eq(20)
+  })
+
+  describe('expectedContributionDelta()', function () {
+    it('positive', function () {
+      const rc = 35
+      const ec = 30
+      const ecd = expectedContributionDelta(ec, rc)
+      expect(ecd).to.eq(5)
+    })
+
+    it('negative', function () {
+      const rc = 30
+      const ec = 35
+      const ecd = expectedContributionDelta(ec, rc)
+      expect(ecd).to.eq(-5)
+    })
+
+    it('exact', function () {
+      const rc = 30
+      const ec = 30
+      const ecd = expectedContributionDelta(ec, rc)
+      expect(ecd).to.eq(0)
+    })
+  })
+
+  describe('effectiveContributionCycles()', function () {
+    const abc = 4
+    const rc = 25
+    const ecc = effectiveContributionCycles(abc, rc)
+    expect(ecc).to.eq(100)
+  })
+
+  describe('learningSupport()', function () {
+    it('round down', function () {
+      const ls = learningSupport([5, 6, 7])
+      expect(ls).to.eq(83)
+    })
+
+    it('round up', function () {
+      const ls = learningSupport([5, 7, 7])
+      expect(ls).to.eq(89)
+    })
+  })
+
+  describe('cultureContrbution()', function () {
+    it('round down', function () {
+      const cc = cultureContrbution([5, 6, 7])
+      expect(cc).to.eq(83)
+    })
+
+    it('round up', function () {
+      const cc = cultureContrbution([5, 7, 7])
+      expect(cc).to.eq(89)
+    })
+  })
+})

--- a/server/util/stats.js
+++ b/server/util/stats.js
@@ -1,0 +1,54 @@
+export function aggregateBuildCycles(numPlayers, numBuildCycles = 1) {
+  if (numPlayers === null || numBuildCycles === null || isNaN(numPlayers) || isNaN(numBuildCycles)) {
+    return null
+  }
+  return numPlayers * numBuildCycles
+}
+
+export function relativeContribution(rcScores) {
+  if (!Array.isArray(rcScores) || !rcScores.length) {
+    return null
+  }
+  const sum = rcScores.reduce((sum, n) => sum + n, 0)
+  return Math.round(sum / rcScores.length)
+}
+
+export function expectedContribution(playerHours, teamHours) {
+  if (playerHours === null || isNaN(playerHours) || !teamHours) {
+    return null
+  }
+  return Math.round((playerHours / teamHours) * 100)
+}
+
+export function expectedContributionDelta(ec, rc) {
+  if (ec === null || rc === null || isNaN(ec) || isNaN(rc)) {
+    return null
+  }
+  return rc - ec
+}
+
+export function effectiveContributionCycles(abc, rc) {
+  if (abc === null || rc === null || isNaN(abc) || isNaN(rc)) {
+    return null
+  }
+  return abc * rc
+}
+
+export function learningSupport(lsScores) {
+  return averageScore(lsScores)
+}
+
+export function cultureContrbution(ccScores) {
+  return averageScore(ccScores)
+}
+
+export const SCORE_MIN = 1
+export const SCORE_MAX = 7
+export function averageScore(scores) {
+  if (!Array.isArray(scores) || !scores.length) {
+    return null
+  }
+  const adjustedScores = scores.filter(n => (n >= SCORE_MIN && n <= SCORE_MAX))
+  const sum = adjustedScores.map(n => ((n - 1) / 6)).reduce((sum, n) => sum + n, 0)
+  return Math.round((sum / adjustedScores.length) * 100)
+}


### PR DESCRIPTION
Fixes https://github.com/LearnersGuild/game/issues/366.

**Main Changes:**
- adds the following to player project cycle stats:
  - `ls` (learning support score)
  - `cc` (culture contribution score)
  - `ec` (expected contribution)
  - `ecd` (expected contribution delta/diff)
  - `hours` (hours worked)

**Other Changes:**
- adds `surveyId` index to `responses` table
- updates, adds tests
