### PR TITLE
Use the `message` attribute if present when creating a GraphQLError

### DIFF
--- a/server/graphql/models/util.js
+++ b/server/graphql/models/util.js
@@ -22,7 +22,7 @@ export function handleError(unparsedError, defaultMsg) {
   if (err.name === 'BadInputError' || err.name === 'LGCustomQueryError') {
     throw err
   }
-  console.error(err.stack)
+  console.error(err.stack || err)
   sentry.captureException(err)
-  throw new GraphQLError(defaultMsg || err)
+  throw new GraphQLError(defaultMsg || err.message || err)
 }


### PR DESCRIPTION
Before:

![_1__rocket_chat](https://cloud.githubusercontent.com/assets/189699/17740355/521520ac-6466-11e6-82a3-1f855c6b2ecc.png)

After:

![_1__rocket_chat 2](https://cloud.githubusercontent.com/assets/189699/17740359/55678556-6466-11e6-90d0-e2442e482521.png)

Fixes #416 
