### PR TITLE
Project import updates

### DIFF
--- a/scripts/importProjects.js
+++ b/scripts/importProjects.js
@@ -1,17 +1,53 @@
-/* eslint-disable import/imports-first */
+/**
+ * Update team members for a collection of projects.
+ * Accepts project config in JSON format. Can be used
+ * to modify an existing project (referenced by name) or
+ * to create a new project (by specifying a valid goal number). If
+ * a new project is created, all normal project setup actions will be executed
+ * as well (creating echo channel, posting welcome message, etc).
+ *
+ * USAGE
+ * =====
+ * Create a JSON file containing the project data you want to import. It should
+ * contain an srray of objects - one object for each project to be updated. Specify
+ * the path to this file in the hardcoded constant below, DATA_FILE_PATH.
+ * TODO: accept path as command line parameter.
+ *
+ * Example - updating an existing project:
+ * [{
+ *   chapterName: 'Oakland',
+ *   cycleNumber: 14,
+ *   projectName: 'boiling-pademelon',
+ *   playerHandles: ['superawsm', 'malookwhaticando']
+ * }]
+ *
+ * Example - creating a NEW project:
+ * [{
+ *   chapterName: 'Oakland',
+ *   cycleNumber: 14,
+ *   goalNumber: 86,
+ *   playerHandles: ['superawsm', 'malookwhaticando']
+ * }]
+ *
+ * To execute, run command: npm run import:projects
+ */
 
-// FIXME: replace globals with central (non-global) config
-global.__SERVER__ = true
+// FIXME: required by an imported module
+global.__SERVER__ = true // eslint-disable import/imports-first
 
 const path = require('path')
 const r = require('src/db/connect')
 const getUsersByHandles = require('src/server/actions/getUsersByHandles')
+const intitiateProjectChannel = require('src/server/actions/intitiateProjectChannel')
+const fetchGoalInfo = require('src/server/actions/fetchGoalInfo')
+const generateProject = require('src/server/actions/generateProject')
+const {insertProjects, getProjectByName} = require('src/server/db/project')
 const {updateInTable} = require('src/server/db/util')
 const {loadJSON} = require('src/server/util')
 const {finish} = require('./util')
 
 const LOG_PREFIX = `${__filename.split('.js')[0]}`
-const DATA_FILE_PATH = path.resolve(__dirname, '../tmp/project-teams.json')
+const DATA_FILE_PATH = path.resolve(__dirname, '../tmp/projects.json')
 
 run()
   .then(() => finish())
@@ -21,7 +57,7 @@ async function run() {
   const errors = []
   const items = await loadJSON(DATA_FILE_PATH, validateProject)
 
-  console.log(LOG_PREFIX, `Importing ${items.length} project teams`)
+  console.log(LOG_PREFIX, `Importing ${items.length} project team(s)`)
 
   const imports = items.map(item => {
     return importProjectTeam(item).catch(err => {
@@ -31,7 +67,7 @@ async function run() {
 
   await Promise.all(imports)
 
-  if (errors.length) {
+  if (errors.length > 0) {
     console.error(LOG_PREFIX, 'Errors:')
     errors.forEach(err => console.log('\n', err))
     throw new Error('Some imports failed')
@@ -39,18 +75,24 @@ async function run() {
 }
 
 function validateProject(data) {
-  const {chapterName, cycleNumber, projectName, playerHandles} = data || {}
+  const {
+    chapterName,
+    cycleNumber,
+    playerHandles,
+    projectName,
+    goalNumber,
+  } = data || {}
 
-  if (typeof chapterName !== 'string' || !chapterName.length) {
+  if (typeof chapterName !== 'string' || chapterName.length === 0) {
     throw new Error('Must specify a valid chapter name')
   }
   if (isNaN(cycleNumber)) {
     throw new Error('Must specify a valid cycle number')
   }
-  if (typeof projectName !== 'string' || !projectName.length) {
-    throw new Error('Must specify a valid project name')
+  if ((typeof projectName !== 'string' || projectName === '') && isNaN(goalNumber)) {
+    throw new Error('Must specify a project name or goal number')
   }
-  if (!Array.isArray(playerHandles) || !playerHandles.length) {
+  if (!Array.isArray(playerHandles) || playerHandles.length === 0) {
     throw new Error('Must specify at least one valid player handle')
   }
 
@@ -61,13 +103,13 @@ async function importProjectTeam(data) {
   const {
     chapterName,
     cycleNumber,
-    projectName,
     playerHandles,
+    projectName,
+    goalNumber,
   } = data
 
-  const [chapters, projects, players] = await Promise.all([
+  const [chapters, players] = await Promise.all([
     r.table('chapters').filter({name: chapterName}),
-    r.table('projects').filter({name: projectName}),
     getUsersByHandles(playerHandles),
   ])
 
@@ -75,13 +117,7 @@ async function importProjectTeam(data) {
   if (!chapter) {
     throw new Error(`Invalid chapter name: ${chapterName}`)
   }
-  const project = projects[0]
-  if (!project) {
-    throw new Error(`Invalid project name: ${projectName}`)
-  }
-  if (project.chapterId !== chapter.id) {
-    throw new Error(`Chapter ID ${chapter.id} does not match project chapter ID ${project.chapterId}`)
-  }
+
   if (players.length !== playerHandles.length) {
     throw new Error(`Found ${players.length} players but expected ${playerHandles.length}`)
   }
@@ -92,17 +128,57 @@ async function importProjectTeam(data) {
     throw new Error(`Invalid cycle number ${cycleNumber} for chapter ${chapterName}`)
   }
 
+  return projectName ?
+    updateProjectTeam(chapter, cycle, projectName, players) :
+    createProject(chapter, cycle, players, goalNumber)
+}
+
+async function updateProjectTeam(chapter, cycle, projectName, players) {
+  const projects = await r.table('projects').filter({name: projectName})
+  const project = projects[0]
+  if (!project) {
+    throw new Error(`Invalid project name: ${projectName}`)
+  }
+  if (project.chapterId !== chapter.id) {
+    throw new Error(`Chapter ID ${chapter.id} for ${chapter.name} does not match project chapter ID ${project.chapterId}`)
+  }
+
   const {cycleHistory = []} = project
   const projectCycle = cycleHistory.find(ch => ch.cycleId === cycle.id)
   if (!projectCycle) {
-    throw new Error(`Invalid cycle number ${cycleNumber} for project ${project.id}`)
+    throw new Error(`Cycle ID ${cycle.id} for number ${cycle.cycleNumber} does not match any cycle for project ${project.id}`)
   }
 
   // overwrite cycle history player IDs
   projectCycle.playerIds = players.map(p => p.id)
 
   console.log(LOG_PREFIX, `Updating player IDs for project ${project.id}`)
+  return updateInTable({id: project.id, cycleHistory}, r.table('projects'))
+}
 
-  const result = await updateInTable({id: project.id, cycleHistory}, r.table('projects'))
-  console.log('result:', result)
+async function createProject(chapter, cycle, players, goalNumber) {
+  // TODO: verify that there isn't already a project in this
+  // chapter and cycle for the same team members
+  const goal = await fetchGoalInfo(chapter.goalRepositoryURL, goalNumber)
+  if (!goal) {
+    throw new Error(`Goal info not found for goal number ${goalNumber}`)
+  }
+
+  const projectValues = await generateProject({
+    chapterId: chapter.id,
+    cycleId: cycle.id,
+    goal,
+    playerIds: players.map(p => p.id),
+  })
+
+  await insertProjects([projectValues])
+
+  const project = await getProjectByName(projectValues.name)
+  if (!project) {
+    throw new Error('Project insert failed')
+  }
+
+  console.log(`\nProject created: #${project.name} (${project.id})`)
+
+  return intitiateProjectChannel(project, players)
 }

--- a/scripts/previewProjects.js
+++ b/scripts/previewProjects.js
@@ -12,7 +12,7 @@ const LOG_PREFIX = `[${__filename.split('js')[0]}]`
 
 // TODO: accept as command line args
 const CHAPTER_NAME = 'Oakland'
-const CYCLE_NUMBER = 12
+const CYCLE_NUMBER = 15
 
 const startedAt = new Date()
 console.log('startedAt:', startedAt)

--- a/scripts/printProjects.js
+++ b/scripts/printProjects.js
@@ -12,7 +12,7 @@ const LOG_PREFIX = `${__filename.split('.js')[0]}`
 
 // TODO: accept as command line args
 const CHAPTER_NAME = 'Oakland'
-const CYCLE_NUMBER = 13
+const CYCLE_NUMBER = 15
 
 run()
   .then(() => finish())

--- a/server/actions/fetchGoalInfo.js
+++ b/server/actions/fetchGoalInfo.js
@@ -1,0 +1,63 @@
+import url from 'url'
+import fetch from 'isomorphic-fetch'
+
+import config from 'src/config'
+
+const TEAM_SIZE_LABEL_PREFIX = 'team-size-'
+
+export default function fetchGoalInfo(goalRepositoryURL, goalDescriptor) {
+  const issueURL = githubIssueURL(goalRepositoryURL, goalDescriptor)
+  if (!issueURL) {
+    return Promise.resolve(null)
+  }
+
+  const fetchOptions = {
+    headers: {
+      Authorization: `token ${config.server.github.tokens.admin}`,
+      Accept: 'application/json',
+    },
+  }
+
+  return fetch(issueURL, fetchOptions)
+    .then(resp => {
+      if (!resp.ok) {
+        // if no issue is found at the given URL, return null
+        if (resp.status === 404) {
+          return null
+        }
+        const respBody = resp.body.read()
+        const errMessage = respBody ? JSON.parse(respBody.toString()) : `FAILED: ${issueURL}`
+        console.error(errMessage)
+        throw new Error(`${errMessage}\n${resp.statusText}`)
+      }
+      return resp.json()
+    })
+    // if no issue is found at the given URL, return null (notify user later)
+    .then(githubIssue => (githubIssue ? {
+      url: githubIssue.html_url,
+      title: githubIssue.title,
+      teamSize: _getTeamSizeFromLabels(githubIssue.labels.map(label => label.name)),
+      githubIssue,
+    } : null))
+}
+
+function githubIssueURL(goalRepositoryURL, goalDescriptor) {
+  goalDescriptor = String(goalDescriptor)
+  const goalRepositoryURLParts = url.parse(goalRepositoryURL)
+  const goalURLParts = url.parse(goalDescriptor)
+  if (goalURLParts.protocol) {
+    // see: http://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+    const escapedGoalRepositoryURL = goalRepositoryURL.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
+    const issueURLRegex = new RegExp(`^${escapedGoalRepositoryURL}\/issues\/\\d+$`)
+    if (goalDescriptor.match(issueURLRegex)) {
+      return `https://api.github.com/repos${goalURLParts.path}`
+    }
+  } else if (goalDescriptor.match(/^\d+$/)) {
+    return `https://api.github.com/repos${goalRepositoryURLParts.path}/issues/${goalDescriptor}`
+  }
+}
+
+function _getTeamSizeFromLabels(labels) {
+  const teamSizeLabel = (labels || []).find(label => (label || '').toLowerCase().startsWith(TEAM_SIZE_LABEL_PREFIX))
+  return teamSizeLabel ? parseInt(teamSizeLabel.split(TEAM_SIZE_LABEL_PREFIX)[1], 10) : null
+}

--- a/server/actions/formProjects.js
+++ b/server/actions/formProjects.js
@@ -16,7 +16,7 @@ import {findVotesForCycle} from 'src/server/db/vote'
 import {insertProjects} from 'src/server/db/project'
 import {toArray, shuffle} from 'src/server/util'
 import createTeamSizes from 'src/server/util/createTeamSizes'
-import generateProjectName from 'src/server/actions/generateProjectName'
+import generateProject from 'src/server/actions/generateProject'
 
 import config from 'src/config'
 
@@ -33,7 +33,7 @@ export async function formProjects(cycleId) {
 export async function buildProjects(cycleId) {
   const cycle = await getCycleById(cycleId)
   const cycleVotes = await findVotesForCycle(cycleId).run()
-  if (!cycleVotes.length) {
+  if (cycleVotes.length === 0) {
     throw new Error('No votes submitted for cycle')
   }
 
@@ -268,16 +268,11 @@ function _formProjectsForGoalGroups(chapterId, cycleId, goalGroups) {
   goalGroups.forEach(goalGroup => {
     goalGroup.teams.forEach(teamPlayers => {
       projects.push(
-        generateProjectName().then(name => {
-          return {
-            chapterId,
-            name,
-            goal: goalGroup.goal,
-            cycleHistory: [{
-              cycleId,
-              playerIds: teamPlayers.map(p => p.id)
-            }],
-          }
+        generateProject({
+          chapterId,
+          cycleId,
+          goal: goalGroup.goal,
+          playerIds: teamPlayers.map(p => p.id),
         })
       )
     })

--- a/server/actions/generateProject.js
+++ b/server/actions/generateProject.js
@@ -1,0 +1,16 @@
+/* eslint-disable prefer-arrow-callback */
+import generateProjectName from 'src/server/actions/generateProjectName'
+
+export default function generateProject({chapterId, cycleId, goal, playerIds}) {
+  return generateProjectName().then(name => {
+    return {
+      chapterId,
+      name,
+      goal,
+      cycleHistory: [{
+        cycleId,
+        playerIds,
+      }],
+    }
+  })
+}

--- a/server/actions/intitiateProjectChannel.js
+++ b/server/actions/intitiateProjectChannel.js
@@ -1,0 +1,35 @@
+import ChatClient from 'src/server/clients/ChatClient'
+
+export default async function intitiateProjectChannel(project, players, options = {}) {
+  const channelName = project.name
+  const chatClient = options.chatClient || new ChatClient()
+
+  console.log(`Initializing project channel #${channelName}`)
+
+  const {goal} = project
+  const goalIssueNum = goal.url.replace(/.*\/(\d+)$/, '$1')
+  const goalLink = `[${goalIssueNum}: ${goal.title}](${goal.url})`
+
+  await chatClient.createChannel(channelName, players.map(p => p.handle).concat('echo'), goalLink)
+
+  // Split welcome message into 2 so that the goal link preview
+  // is inserted right after the goal link.
+  const projectWelcomeMessage1 = `🎊 *Welcome to the ${channelName} project channel!* 🎊
+
+*Your goal is:* ${goalLink}
+`
+
+  const projectWelcomeMessage2 = `*Your team is:*
+  ${players.map(p => `• _${p.name}_ - @${p.handle}`).join('\n  ')}
+
+*Time to start work on your project!*
+
+The first step is to create an appropriate project artifact.
+Once you've created the artifact, connect it to your project with the \`/project set-artifact\` command.
+
+Run \`/project set-artifact --help\` for more guidance.
+`
+
+  await chatClient.sendChannelMessage(channelName, projectWelcomeMessage1)
+  await chatClient.sendChannelMessage(channelName, projectWelcomeMessage2)
+}

--- a/server/actions/sendCycleLaunchAnnouncement.js
+++ b/server/actions/sendCycleLaunchAnnouncement.js
@@ -1,0 +1,13 @@
+import r from 'src/db/connect'
+import ChatClient from 'src/server/clients/ChatClient'
+
+export default function sendCycleLaunchAnnouncement(cycle, projects, options = {}) {
+  const chatClient = options.chatClient || new ChatClient()
+  const projectListString = projects.map(p => `#${p.name} - _${p.goal.title}_`).join('\n  • ')
+  const announcement = `🚀  *The cycle has been launched!*
+The following projects have been created:
+  • ${projectListString}`
+
+  return r.table('chapters').get(cycle.chapterId).run()
+    .then(chapter => chatClient.sendChannelMessage(chapter.channelName, announcement))
+}

--- a/server/workers/cycleLaunched.js
+++ b/server/workers/cycleLaunched.js
@@ -1,14 +1,16 @@
+/* eslint-disable prefer-arrow-callback */
 import raven from 'raven'
 
 import config from 'src/config'
-import r from 'src/db/connect'
-import getPlayerInfo from 'src/server/actions/getPlayerInfo'
 import {formProjects} from 'src/server/actions/formProjects'
+import intitiateProjectChannel from 'src/server/actions/intitiateProjectChannel'
+import sendCycleLaunchAnnouncement from 'src/server/actions/sendCycleLaunchAnnouncement'
+import getPlayerInfo from 'src/server/actions/getPlayerInfo'
 import {findModeratorsForChapter} from 'src/server/db/moderator'
 import {getTeamPlayerIds, getProjectsForChapterInCycle} from 'src/server/db/project'
 import {update as updateCycle} from 'src/server/db/cycle'
 import {parseQueryError} from 'src/server/db/errors'
-import {CYCLE_STATES} from 'src/common/models/cycle'
+import {GOAL_SELECTION} from 'src/common/models/cycle'
 import {getQueue, getSocket} from 'src/server/util'
 import ChatClient from 'src/server/clients/ChatClient'
 
@@ -35,51 +37,13 @@ export async function processCycleLaunch(cycle, options = {}) {
   await formProjects(cycle.id)
   const projects = await getProjectsForChapterInCycle(cycle.chapterId, cycle.id)
 
-  await Promise.all(projects.map(project => {
-    return initializeProjectChannel(chatClient, project.name, getTeamPlayerIds(project, cycle.id), project.goal)
+  await Promise.all(projects.map(async project => {
+    const playerIds = await getTeamPlayerIds(project, cycle.id)
+    const players = await getPlayerInfo(playerIds)
+    return intitiateProjectChannel(project, players, {chatClient})
   }))
 
-  return sendCycleLaunchAnnouncement(chatClient, cycle, projects)
-}
-
-async function initializeProjectChannel(chatClient, channelName, playerIds, goal) {
-  console.log(`Initializing project channel ${channelName}`)
-  const goalIssueNum = goal.url.replace(/.*\/(\d+)$/, '$1')
-  const goalLink = `[${goalIssueNum}: ${goal.title}](${goal.url})`
-
-  const players = await getPlayerInfo(playerIds)
-  await chatClient.createChannel(channelName, players.map(p => p.handle).concat('echo'), goalLink)
-
-  // Split welcome message into 2 so that the goal link preview
-  // is inserted right after the goal link.
-  const projectWelcomeMessage1 = `🎊 *Welcome to the ${channelName} project channel!* 🎊
-
-*Your goal is:* ${goalLink}
-`
-
-  const projectWelcomeMessage2 = `*Your team is:*
-  ${players.map(p => `• _${p.name}_ - @${p.handle}`).join('\n  ')}
-
-*Time to start work on your project!*
-
-The first step is to create an appropriate project artifact.
-Once you've created the artifact, connect it to your project with the \`/project set-artifact\` command.
-
-Run \`/project set-artifact --help\` for more guidance.
-`
-
-  await chatClient.sendChannelMessage(channelName, projectWelcomeMessage1)
-  await chatClient.sendChannelMessage(channelName, projectWelcomeMessage2)
-}
-
-function sendCycleLaunchAnnouncement(chatClient, cycle, projects) {
-  const projectListString = projects.map(p => `#${p.name} - _${p.goal.title}_`).join('\n  • ')
-  const announcement = `🚀  *The cycle has been launched!*
-The following projects have been created:
-  • ${projectListString}`
-
-  return r.table('chapters').get(cycle.chapterId).run()
-    .then(chapter => chatClient.sendChannelMessage(chapter.channelName, announcement))
+  return sendCycleLaunchAnnouncement(cycle, projects, {chatClient})
 }
 
 async function _handleCycleLaunchError(cycle, err) {
@@ -91,8 +55,7 @@ async function _handleCycleLaunchError(cycle, err) {
   try {
     // reset cycle state to GOAL_SELECTION
     console.log(`Resetting state for cycle ${cycle.id} to GOAL_SELECTION`)
-    const goalSelectionCycleState = CYCLE_STATES[0] // FIXME: yuck!
-    await updateCycle({id: cycle.id, state: goalSelectionCycleState})
+    await updateCycle({id: cycle.id, state: GOAL_SELECTION})
   } catch (err) {
     console.error('Cycle state reset error:', err)
   }


### PR DESCRIPTION
- extracts project channel setup code from cycle launched worker to standalone server actions
- allows specification of a `goalNumber` instead of a `projectName` in JSON to create a new project instead of updating an existing one
- when importing a **new** project (^), initializes project channel in echo
