### PR TITLE
disabling codeclimate linting

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,14 +11,7 @@ engines:
       - python
       - php
   eslint:
-    enabled: true
-    checks:
-      global-require:
-        enabled: false
-      comma-dangle:
-        enabled: false
-      semi:
-        enabled: false
+    enabled: false
   fixme:
     enabled: true
 ratings:


### PR DESCRIPTION
Fixes #514 
# Description

Codeclimate doesn't support XO, we would have to maintain a separate
eslint config and keep it in sync with XO to get it to work properly.
Currently many files just have parse errors because the current config
doesn't like our ES6-isms like async and spread.

Since we already do linting as part of the CI build, I think this is safe to turn off.
# Config

nope
# Env

nope
# Notes

nope
