### PR TITLE
[HOLD] Less chance of team members stuck with people they didn't want to work with

### DIFF
--- a/server/services/projectFormationService/lib/ObjectiveAppraiser/index.js
+++ b/server/services/projectFormationService/lib/ObjectiveAppraiser/index.js
@@ -10,7 +10,7 @@ const WEIGHTED_OBJECTIVES = [
   ['TeamSizesMatchRecommendation', 100],
   ['NonAdvancedPlayersGotTheirVote', 10],
   ['AdvancedPlayersGotTheirVote', 10],
-  ['PlayersGetTeammatesTheyGaveGoodFeedback', 30],
+  ['PlayersGetTeammatesTheyGaveGoodFeedback', 10],
 ]
 
 function load(objective) {


### PR DESCRIPTION
## Overview

Last project formation algorithm, there were 5 pairs out of 17 that had repeat pairings. 

This PR increases importance/weight of new team members over team members that have worked together before, and prioritizes team-mate feedback in team formation over players getting what they voted for. 
## Data Model / DB Schema Changes

none
## Environment / Configuration Changes

none
## Notes

As a player, social/emotional cost of landing on the same pair again for 3rd or 4th time is pretty high. Way higher than landing on a project I didn't vote for. 
