### PR TITLE
Compute and surface challenge stat

### DIFF
--- a/common/models/stat.js
+++ b/common/models/stat.js
@@ -9,4 +9,5 @@ export const STAT_DESCRIPTORS = {
   RESULTS_FOCUS: 'resultsFocus',
   FLEXIBLE_LEADERSHIP: 'flexibleLeadership',
   FRICTION_REDUCTION: 'frictionReduction',
+  CHALLENGE: 'challenge',
 }

--- a/db/data/questions.yaml
+++ b/db/data/questions.yaml
@@ -165,6 +165,7 @@
     8 = Slightly more challenged than is fun
     10 = Completely overwhelmed
   responseType: numeric
+  statId: af6445a3-f631-411f-84b3-d6aaea87d6dc
   validationOptions:
     min: 1
     max: 10

--- a/db/data/stats.yaml
+++ b/db/data/stats.yaml
@@ -44,3 +44,6 @@
 -
   id: 8d93d767-d0a1-48a4-848c-8663b7f997f1
   descriptor: frictionReduction
+-
+  id: af6445a3-f631-411f-84b3-d6aaea87d6dc
+  descriptor: challenge

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "workers": "npm run symlinks && ./node_modules/.bin/babel-node ./server/workers",
     "workers:cycleLaunched": "npm run symlinks && ./node_modules/.bin/babel-node ./server/workers/cycleLaunched",
     "icons:fetch": "mkdir -p dist && curl -s https://brand.learnersguild.org/icontags > dist/icons-metadata.json",
+    "data:reloadFromFiles": "npm run symlinks && ./node_modules/.bin/babel-node scripts/reloadDataFiles",
     "data:playtest": "npm run symlinks && ./node_modules/.bin/babel-node test/generatePlaytestData",
     "data:github-goals": "npm run symlinks && ./node_modules/.bin/babel-node test/generateTestGoals",
     "data:import:survey-responses": "npm run symlinks && ./node_modules/.bin/babel-node scripts/importSurveyResponses",

--- a/scripts/reloadDataFiles.js
+++ b/scripts/reloadDataFiles.js
@@ -1,0 +1,9 @@
+/* eslint-disable xo/no-process-exit */
+import reloadSurveyAndQuestionData from 'src/server/actions/reloadSurveyAndQuestionData'
+import {finish} from './util'
+
+console.log('Reloading Data Files')
+
+reloadSurveyAndQuestionData()
+  .then(() => finish())
+  .catch(finish)

--- a/server/actions/__tests__/updateProjectStats.test.js
+++ b/server/actions/__tests__/updateProjectStats.test.js
@@ -30,10 +30,12 @@ describe(testContext(__filename), function () {
         {value: 3, questionId: await getQId(STAT_DESCRIPTORS.RESULTS_FOCUS)},
         {value: 2, questionId: await getQId(STAT_DESCRIPTORS.FRICTION_REDUCTION)},
         {value: 20, questionId: await getQId(STAT_DESCRIPTORS.RELATIVE_CONTRIBUTION)},
+        {value: 7, questionId: await getQId(STAT_DESCRIPTORS.CHALLENGE)},
       ]
 
       const projectQuestions = [
-        {name: 'projectHoursQuestion', value: '35', questionId: await getQId(STAT_DESCRIPTORS.PROJECT_HOURS)},
+        {value: '35', questionId: await getQId(STAT_DESCRIPTORS.PROJECT_HOURS)},
+        {value: 7, questionId: await getQId(STAT_DESCRIPTORS.CHALLENGE)},
       ]
 
       await this.buildSurvey([
@@ -88,6 +90,7 @@ describe(testContext(__filename), function () {
         },
         projects: {
           [this.project.id]: {
+            challenge: 7,
             cc: 100,
             th: 83,
             receptiveness: 67,

--- a/server/actions/updateProjectStats.js
+++ b/server/actions/updateProjectStats.js
@@ -95,6 +95,7 @@ export default async function updateProjectStats(project, cycleId) {
 
     stats.teamHours = teamHours
     stats.hours = teamPlayerHours.get(playerSubjectId) || 0
+    stats.challenge = _getChallenge(retroResponses, player, statsQuestions)
     const scores = _extractPlayerScores(statsQuestions, playerResponseGroup, playerSubjectId)
     stats.abc = aggregateBuildCycles(projectTeamPlayers.length)
     stats.th = technicalHealth(scores.th)
@@ -146,6 +147,7 @@ async function _findStatsQuestions(questions) {
     flexibleLeadership: getQ(STAT_DESCRIPTORS.FLEXIBLE_LEADERSHIP),
     frictionReduction: getQ(STAT_DESCRIPTORS.FRICTION_REDUCTION),
     hours: getQ(STAT_DESCRIPTORS.PROJECT_HOURS),
+    challenge: getQ(STAT_DESCRIPTORS.CHALLENGE),
   }
 }
 
@@ -245,6 +247,13 @@ function _extractPlayerScores(statsQuestions, playerResponseGroup, playerSubject
   })
 
   return scores
+}
+
+function _getChallenge(retroResponses, player, statsQuestions) {
+  const challengeResponse = retroResponses.find(response =>
+    response.respondentId === player.id &&
+    response.questionId === statsQuestions.challenge.id)
+  return (challengeResponse || {}).value
 }
 
 function _updatePlayerRatings(playerStats) {

--- a/server/reports/playerStatHelpers.js
+++ b/server/reports/playerStatHelpers.js
@@ -15,6 +15,7 @@ const STAT_MAPPING = {
   est_accuracy: 'accuracy',
   avg_proj_comp: 'completeness',
   avg_proj_qual: 'quality',
+  challenge: 'challenge',
 }
 
 const RECENT_CYCLE_RANGE = 6
@@ -26,7 +27,10 @@ export const avgStat = statName => {
 
   return player => {
     const obj = {}
-    obj[statName] = player('recentProjs').avg(dbProp).default(0)
+    obj[statName] = player('recentProjs')
+      .filter(p => p.hasFields(dbProp))
+      .avg(dbProp)
+      .default(0)
     return obj
   }
 }

--- a/server/reports/playerStats.js
+++ b/server/reports/playerStats.js
@@ -33,6 +33,7 @@ const HEADERS = [
   'est_bias',
   'no_proj_rvws',
   'elo',
+  'challenge',
 ]
 
 const DEFAULT_CHAPTER = 'Oakland'
@@ -64,6 +65,7 @@ async function statReport(params) {
              .and(r.row('stats').hasFields('projects'))))
     .merge(avgProjHours)
     .merge(recentProjStats(latestProjIds))
+    .merge(avgStat('challenge'))
     .merge(avgStat('health_culture'))
     .merge(avgStat('health_team_play'))
     .merge(avgStat('health_technical'))
@@ -87,6 +89,7 @@ async function statReport(params) {
         avg_proj_qual: player('avg_proj_qual'),
         no_proj_rvws: player('no_proj_rvws'),
         elo: player('stats')('elo')('rating'),
+        challenge: player('challenge'),
       }
     })
 }


### PR DESCRIPTION
Fixes #528 

## Overview

Adds challenge to player.stats and playerStats report

## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

A new stat has been added to the `stats.yaml` file and linked to from a question in `questions.yaml`. You'll need to run this to update your database:

```bash
npm run data:reloadFromFiles
```

Then, recalculate stats with:

```bash
npm run stats
```

This will need to be done in prod as well after deployment.

## Notes

* I've added the `npm run data:reloadFromFiles` command for convenience.
* This feels like too much work to add a simple stat, still planning to generalize this code so that it's more data driven from the stats entries in the db and relies less on hard coded stat descriptors.

