### PR TITLE
Removing heuristic player assignment strategy in favor of exhastive approach

### DIFF
--- a/server/services/projectFormationService/lib/teamFormationPlan.js
+++ b/server/services/projectFormationService/lib/teamFormationPlan.js
@@ -8,7 +8,7 @@ export function teamFormationPlanToString(plan) {
     const playerIdPrefixes = playerIds.map(id => id.slice(0, 7))
     const goalDescriptorSuffix = goalDescriptor.split('/').pop()
 
-    return `(${goalDescriptorSuffix}:${teamSize})[${playerIdPrefixes || ''}]`
+    return `(${goalDescriptorSuffix}:${teamSize})[${playerIdPrefixes.sort() || ''}]`
   }).join(', ')
 }
 


### PR DESCRIPTION
Fixes #537 

## Overview

The projects created by the PFA for cycle 17 had too many people working with repeat team members even when, in some cases, they didn't even rate each other that well. Better teams could have been formed without sacrificing anyone's vote, even when taking into consideration how the pools were split.

The cause of this was a heuristic we were using that was "cheating" by making assumptions about our objectives. Specifically, it was only looking at a subset of player assignments that were likely to be scored well by the "PlayersGotTheirVotes" appraiser.

When the only thing we cared about once team sizes and goals were chosen
was player votes, we could use a heuristic method to get 50 permutations
of player assignments that would all be pretty likely to score well. Now
that we're looking at player feedback as well this heuristic method was
no longer working very well. Since the pool is currently being spwe can
get away with an exhaustive strategy so I'm removing the heuristic
strategy altogether.

This will yield much better results and also removed some randomness
from the algorithm so we'll get a deterministic result.

## Data Model / DB Schema Changes

🚫 

## Environment / Configuration Changes

🚫 

## Notes

🚫 