### PR TITLE
handle db write errors

### DIFF
--- a/scripts/runStats.js
+++ b/scripts/runStats.js
@@ -6,12 +6,16 @@ global.__SERVER__ = true
 const Promise = require('bluebird')
 
 const updateProjectCycleStats = require('src/server/actions/updateProjectStats')
+const {connect} = require('src/db')
+const {checkForWriteErrors} = require('src/server/db/util')
 const {findPlayers, getPlayerById} = require('src/server/db/player')
 const {findChapters} = require('src/server/db/chapter')
 const {getCyclesForChapter} = require('src/server/db/cycle')
 const {findProjects} = require('src/server/db/project')
 const {COMPLETE} = require('src/common/models/cycle')
 const {finish} = require('./util')
+
+const r = connect()
 
 const LOG_PREFIX = '[runStats]'
 
@@ -80,8 +84,8 @@ async function clearPlayerStats(player) {
   console.log(LOG_PREFIX, `Clearing stats for player ${player.id}`)
 
   await getPlayerById(player.id)
-    .replace(player => player.without('stats'))
-    .run()
+    .replace(player => player.without('stats').merge({updatedAt: r.now()}))
+    .then(checkForWriteErrors)
 }
 
 async function setPlayerStats(player, stats) {

--- a/server/db/__tests__/chapter.test.js
+++ b/server/db/__tests__/chapter.test.js
@@ -1,0 +1,35 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+import factory from 'src/test/factories'
+import {withDBCleanup} from 'src/test/helpers'
+
+import {
+  saveChapter,
+  getChapterById,
+  chaptersTable,
+} from 'src/server/db/chapter'
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+
+  describe('saveChapter()', function () {
+    beforeEach(async function () {
+      this.chapter = await factory.create('chapter')
+    })
+
+    it('updates existing record when id provided', function () {
+      const updatedChapter = Object.assign({}, this.chapter, {newAttr: 'newVal'})
+      return saveChapter(updatedChapter)
+        .then(() => getChapterById(this.chapter.id))
+        .then(savedRecord => expect(savedRecord).to.have.property('newAttr', 'newVal'))
+    })
+
+    it('saves a new record when new id provided', async function () {
+      const newChapter = await factory.build('chapter')
+      await saveChapter(newChapter)
+      const count = await chaptersTable.count()
+      expect(count).to.eq(2)
+    })
+  })
+})

--- a/server/db/__tests__/vote.test.js
+++ b/server/db/__tests__/vote.test.js
@@ -1,0 +1,35 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+import factory from 'src/test/factories'
+import {withDBCleanup} from 'src/test/helpers'
+
+import {
+  saveVote,
+  getVoteById,
+  votesTable,
+} from 'src/server/db/vote'
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+
+  describe('saveVote()', function () {
+    beforeEach(async function () {
+      this.vote = await factory.create('vote')
+    })
+
+    it('updates existing record when id provided', function () {
+      const updatedVote = Object.assign({}, this.vote, {newAttr: 'newVal'})
+      return saveVote(updatedVote)
+        .then(() => getVoteById(this.vote.id))
+        .then(savedRecord => expect(savedRecord).to.have.property('newAttr', 'newVal'))
+    })
+
+    it('saves a new record when new id provided', async function () {
+      const newVote = await factory.build('vote')
+      await saveVote(newVote)
+      const count = await votesTable.count()
+      expect(count).to.eq(2)
+    })
+  })
+})

--- a/server/db/chapter.js
+++ b/server/db/chapter.js
@@ -1,4 +1,5 @@
 import {connect} from 'src/db'
+import {insertIntoTable, replaceInTable} from 'src/server/db/util'
 
 const r = connect()
 export const chaptersTable = r.table('chapters')
@@ -9,4 +10,20 @@ export function getChapterById(chapterId) {
 
 export function findChapters() {
   return chaptersTable
+}
+
+export function saveChapter(chapter, options) {
+  if (chapter.id) {
+    return replace(chapter, options)
+  }
+
+  return insert(chapter, options)
+}
+
+function replace(chapter, options) {
+  return replaceInTable(chapter, chaptersTable, options)
+}
+
+function insert(chapter, options) {
+  return insertIntoTable(chapter, chaptersTable, options)
 }

--- a/server/db/moderator.js
+++ b/server/db/moderator.js
@@ -1,4 +1,5 @@
 import {connect} from 'src/db'
+import {replaceInTable} from 'src/server/db/util'
 
 const r = connect()
 const table = r.table('moderators')
@@ -22,4 +23,8 @@ export function getModeratorById(id, passedOptions = {}) {
 export function findModeratorsForChapter(chapterId, filters) {
   const moderators = table.getAll(chapterId, {index: 'chapterId'})
   return filters ? moderators.filter(filters) : moderators
+}
+
+export function replace(record, options) {
+  return replaceInTable(record, table, options)
 }

--- a/server/db/player.js
+++ b/server/db/player.js
@@ -1,13 +1,14 @@
 import {connect} from 'src/db'
-import {updateInTable} from 'src/server/db/util'
+import {updateInTable, replaceInTable} from 'src/server/db/util'
 
 const r = connect()
+export const playersTable = r.table('players')
 
 export function getPlayerById(id, passedOptions = {}) {
   const options = Object.assign({
     mergeChapter: false,
   }, passedOptions)
-  const player = r.table('players').get(id)
+  const player = playersTable.get(id)
   return r.branch(
     player.eq(null),
     player,
@@ -20,7 +21,7 @@ export function getPlayerById(id, passedOptions = {}) {
 }
 
 export function findPlayersByIds(playerIds) {
-  return r.table('players').getAll(...playerIds)
+  return playersTable.getAll(...playerIds)
 }
 
 export function savePlayerProjectStats(playerId, projectId, newStats = {}) {
@@ -64,7 +65,7 @@ function _updatedSummaryStatExpr(projectId, newStats, statName) {
 export function reassignPlayersToChapter(playerIds, chapterId) {
   const now = r.now()
 
-  return r.table('players')
+  return playersTable
     .getAll(...playerIds)
     .filter(r.row('chapterId').ne(chapterId))
     .update({
@@ -85,24 +86,28 @@ export function reassignPlayersToChapter(playerIds, chapterId) {
 }
 
 export function findPlayers(options) {
-  const players = r.table('players')
+  const players = playersTable
   return options && options.filter ?
     players.filter(options.filter) :
     players
 }
 
 export function findPlayersForChapter(chapterId, filters) {
-  return r.table('players')
+  return playersTable
     .getAll(chapterId, {index: 'chapterId'})
     .filter(filters || {})
 }
 
 export function getActivePlayersInChapter(chapterId) {
-  return r.table('players')
+  return playersTable
     .getAll(chapterId, {index: 'chapterId'})
     .filter({active: true})
 }
 
 export function update(record, options) {
-  return updateInTable(record, r.table('players'), options)
+  return updateInTable(record, playersTable, options)
+}
+
+export function replace(record, options) {
+  return replaceInTable(record, playersTable, options)
 }

--- a/server/db/util.js
+++ b/server/db/util.js
@@ -33,7 +33,9 @@ export function replaceInTable(record, table, options = {}) {
     addTimestamps(record, 'updatedAt') :
     addTimestamps(record, ['createdAt', 'updatedAt'])
 
-  return table.get(record.id).replace(recordWithTimestamps, options)
+  return table.get(record.id)
+    .replace(recordWithTimestamps, options)
+    .then(result => checkForWriteErrors(result))
 }
 
 export function checkForWriteErrors(result) {

--- a/server/db/vote.js
+++ b/server/db/vote.js
@@ -1,9 +1,31 @@
 import {connect} from 'src/db'
+import {insertIntoTable, replaceInTable} from 'src/server/db/util'
 
 const r = connect()
+export const votesTable = r.table('votes')
 
 export function findVotesForCycle(cycleId, filters) {
   return r.table('votes')
     .getAll(cycleId, {index: 'cycleId'})
     .filter(filters || {})
+}
+
+export function getVoteById(voteId) {
+  return votesTable.get(voteId)
+}
+
+export function saveVote(vote, options) {
+  if (vote.id) {
+    return replace(vote, options)
+  }
+
+  return insert(vote, options)
+}
+
+function replace(vote, options) {
+  return replaceInTable(vote, votesTable, options)
+}
+
+function insert(vote, options) {
+  return insertIntoTable(vote, votesTable, options)
 }

--- a/server/graphql/models/Vote/__tests__/mutation.test.js
+++ b/server/graphql/models/Vote/__tests__/mutation.test.js
@@ -68,12 +68,10 @@ describe(testContext(__filename), function () {
     })
 
     describe('when player has already voted', function () {
-      beforeEach(function () {
-        return factory.create('vote', {
+      beforeEach(async function () {
+        this.initialVote = await factory.create('vote', {
           playerId: this.player.id,
-          cycleId: this.cycle.id
-        }).then(vote => {
-          this.initialVote = vote
+          cycleId: this.cycle.id,
         })
       })
 

--- a/server/workers/newGameUser.js
+++ b/server/workers/newGameUser.js
@@ -4,6 +4,8 @@ import raven from 'raven'
 import config from 'src/config'
 import {connect} from 'src/db'
 import {getQueue} from 'src/server/util'
+import {replace as replacePlayer} from 'src/server/db/player'
+import {replace as replaceModerator} from 'src/server/db/moderator'
 import {notifyContactSignedUp} from 'src/server/clients/CRMClient'
 
 const r = connect()
@@ -11,8 +13,8 @@ const sentry = new raven.Client(config.server.sentryDSN)
 
 const upsertToDatabase = {
   // we use .replace() instead of .insert() in case we get duplicates in the queue
-  moderator: gameUser => r.table('moderators').get(gameUser.id).replace(gameUser, {returnChanges: 'always'}).run(),
-  player: gameUser => r.table('players').get(gameUser.id).replace(gameUser, {returnChanges: 'always'}).run(),
+  moderator: gameUser => replaceModerator(gameUser, {returnChanges: 'always'}),
+  player: gameUser => replacePlayer(gameUser, {returnChanges: 'always'}),
 }
 
 async function addUserToDatabase(user) {

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -4,7 +4,7 @@ import factory from '../../test/factories'
 import {
   getProjectById,
   updateProject,
-  table as projectsTable,
+  insertProjects,
 } from '../../server/db/project'
 import {getCycleById} from '../../server/db/cycle'
 
@@ -85,7 +85,7 @@ export const useFixture = {
         this.projects.slice(1).forEach(project => {
           project.cycleId = this.projects[0].cycleId
         })
-        await projectsTable.insert(this.projects)
+        await insertProjects(this.projects)
         this.cycle = await getCycleById(this.projects[0].cycleId)
 
         // create a project review survey for each project


### PR DESCRIPTION
Fixes #110

## Overview

rethinkdb write operations can return errors in the return value without
actually 'throw'ing and error if the initial connection succeeded. These
changes add checks for those returned errors where there were none.

## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

none

## Notes

none