### PR TITLE
increase "popular goals" count in PFA from 6 to 10

### DIFF
--- a/server/services/projectFormationService/lib/ObjectiveAppraiser/UnpopularGoalsNotConsideredAppraiser.js
+++ b/server/services/projectFormationService/lib/ObjectiveAppraiser/UnpopularGoalsNotConsideredAppraiser.js
@@ -6,7 +6,7 @@ import {
 import PlayersGotTheirVoteAppraiser from './PlayersGotTheirVoteAppraiser'
 
 export default class UnpopularGoalsNotConsideredAppraiser {
-  constructor(pool, maxPopularGoals = 6) {
+  constructor(pool, maxPopularGoals = 10) {
     this.pool = pool
     this.maxPopularGoals = maxPopularGoals
   }


### PR DESCRIPTION
Fixes #553

## Overview

We limit the number of goals we consider to same time. With lots of 2-player teams however, even unpopular goals can be part of an optimal solution, so we're cranking this up. We can get away with it because the pools are small.

## Data Model / DB Schema Changes

no

## Environment / Configuration Changes

no
