### PR TITLE
fix `/retro`

### DIFF
--- a/server/db/project.js
+++ b/server/db/project.js
@@ -53,9 +53,10 @@ export async function findProjectBySurveyId(surveyId) {
 }
 
 export function findProjectByPlayerIdAndCycleId(playerId, cycleId) {
-  const projectFilter = project => (
-    project('cycleId').eq(cycleId) &&
-    project('playerIds').contains(playerId))
+  const projectFilter = project => r.and(
+    project('cycleId').eq(cycleId),
+    project('playerIds').contains(playerId)
+  )
 
   const projectsQuery = findProjects(projectFilter)
 


### PR DESCRIPTION
Fixes #560 

## Overview

fixing bug in findProjectByPlayerIdAndCycleId: Replaced erroneous `a && b` in a rethinkdb query with `r.and(a, b)`

Also added tests!

## Data Model / DB Schema Changes

nobe

## Environment / Configuration Changes

none

## Notes

nope