### PR TITLE
adding logic to processJobs to cleanup completed jobs after 30 days

### DIFF
--- a/server/util/queue.js
+++ b/server/util/queue.js
@@ -62,9 +62,10 @@ export function processJobs(queueName, processor, onFailed = _defaultErrorHandle
 function _setupCompletedJobCleaner(queueName, queue) {
   /* eslint-disable no-implicit-coercion */
   const day = 1000 * 86400
-  const maxJobAge = 30 * day
-  const cleanInterval = 1 * day
-  const cleanJobs = () => queue.clean(maxJobAge, 'completed')
+  const cleanJobs = () => {
+    queue.clean(30 * day, 'completed')
+    queue.clean(90 * day, 'failed')
+  }
 
   queue.on('cleaned', (jobs, type) => {
     console.log(`Cleaned ${jobs.length} ${type} jobs from ${queueName} queue`)
@@ -74,7 +75,7 @@ function _setupCompletedJobCleaner(queueName, queue) {
   cleanJobs()
 
   // Clean periodically
-  setInterval(cleanJobs, cleanInterval)
+  setInterval(cleanJobs, 1 * day)
 }
 
 function _assertIsFunction(func, name) {


### PR DESCRIPTION
Fixes #562

## Overview

Purging completed jobs over 30 days old from the queues. Checking on startup and then once a day.

## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

none

## Notes

* Hooking into the new `processJobs` helper seemed to make the most sense here, so that we'll get completed job cleanup for free along with error handling. If we ever have a need to create a queue and put jobs on it that won't be consumed by by game (which we surely will eventually) we'll need to think about how to handle job cleanup in that case. At that point I could imagine a small watcher service whose job is just to watch the queues and do cleanup (and maybe run the admin interface for bull queue?).

* Linting =/

I chose this:

```javascript
/* eslint-disable no-implicit-coercion */
const day = 1000 * 86400
const maxJobAge = 30 * day
const cleanInterval = 1 * day
```

over this:

```javascript
const day = 1000 * 86400
const maxJobAge = 30 * Number(day)
const cleanInterval = 1 * Number(day)
```

I don't like either option, so if you like the latter let me know and I'm happy to change it.