### PR TITLE
move changefeed listeners from web process to worker process

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -10,7 +10,6 @@ import raven from 'raven'
 import config from 'src/config'
 import configureApp from './configureApp'
 import configureSocketCluster from './configureSocketCluster'
-import configureChangeFeeds from './configureChangeFeeds'
 
 import {default as renderApp} from './render'
 
@@ -75,9 +74,6 @@ export function start() {
 
   // socket cluster
   configureSocketCluster(httpServer)
-
-  // change feeds
-  configureChangeFeeds()
 
   return httpServer.listen(config.server.port, error => {
     if (error) {

--- a/server/workers/index.js
+++ b/server/workers/index.js
@@ -1,6 +1,7 @@
 global.__CLIENT__ = false
 global.__SERVER__ = true
 
+// start workers
 require('./newGameUser').start()
 require('./newChapter').start()
 require('./newOrUpdatedVote').start()
@@ -9,3 +10,6 @@ require('./cycleReflectionStarted').start()
 require('./cycleCompleted').start()
 require('./projectArtifactChanged').start()
 require('./surveyResponseSubmitted').start()
+
+// start change feed listeners
+require('src/server/configureChangeFeeds')()


### PR DESCRIPTION
Fixes #585.

## Overview

This PR moves the changefeed listeners for RethinkDB out of the web process and into the main worker process. The hope is that this will prevent the NewRelic appdex degradations that we see every Friday.

## Data Model / DB Schema Changes

N/A

## Environment / Configuration Changes

N/A

## Notes

N/A