### PR TITLE
promise should be rejected with an Error

### DIFF
--- a/server/clients/ChatClient.js
+++ b/server/clients/ChatClient.js
@@ -79,7 +79,7 @@ export default class ChatClient {
       })
       .then(json => {
         if (json.status !== 'success') {
-          return Promise.reject(json)
+          return Promise.reject(new Error(json.message))
         }
         return json
       })


### PR DESCRIPTION
## Overview

Noticed this issue while reviewing an unrelated PR. Rejecting this promise with the parsed json object instead of an `Error` object causes warnings to be logged about rejecting a promise with a non-error while the actual error message is NOT logged.