### PR TITLE
Change PFA Weights to Prioritize Teammate Novelty

### DIFF
--- a/server/services/projectFormationService/lib/ObjectiveAppraiser/PlayersGetTeammatesTheyGaveGoodFeedbackAppraiser.js
+++ b/server/services/projectFormationService/lib/ObjectiveAppraiser/PlayersGetTeammatesTheyGaveGoodFeedbackAppraiser.js
@@ -14,7 +14,7 @@ export const STAT_WEIGHTS = {
   [FEEDBACK_STAT_DESCRIPTORS.TECHNICAL_HEALTH]: 0.25
 }
 
-export const NOVELTY_WEIGHT = 0.3
+export const NOVELTY_WEIGHT = 1
 export const PERFECT_SCORE = sum([...Object.values(STAT_WEIGHTS), NOVELTY_WEIGHT])
 
 export default class PlayersGetTeammatesTheyGaveGoodFeedbackAppraiser {

--- a/server/services/projectFormationService/lib/ObjectiveAppraiser/index.js
+++ b/server/services/projectFormationService/lib/ObjectiveAppraiser/index.js
@@ -7,7 +7,7 @@ const MANDATORY_OBJECTIVES = [
 const WEIGHTED_OBJECTIVES = [
   ['TeamSizesMatchRecommendation', 100],
   ['PlayersGotTheirVote', 10],
-  ['PlayersGetTeammatesTheyGaveGoodFeedback', 10],
+  ['PlayersGetTeammatesTheyGaveGoodFeedback', 30],
 ]
 
 function load(objective) {


### PR DESCRIPTION
Fixes #647

## Overview

Just changing some constants to make the PFA give more weight teams where people are working with folks they never have before.

## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

none