### PR TITLE
Fixing nocking

### DIFF
--- a/server/actions/__tests__/importProject.test.js
+++ b/server/actions/__tests__/importProject.test.js
@@ -27,10 +27,6 @@ describe(testContext(__filename), function () {
     }
   })
   beforeEach(function () {
-    useFixture.nockIDMfindUsers(this.users)
-    useFixture.nockfetchGoalInfo(this.goalNumber)
-  })
-  afterEach(function () {
     useFixture.nockClean()
   })
 
@@ -51,7 +47,9 @@ describe(testContext(__filename), function () {
     })
 
     it('creates a new project a projectIdentifier is not specified', async function () {
-      useFixture.nockfetchGoalInfo(this.goalNumber)
+      useFixture.nockIDMfindUsers(this.users)
+      useFixture.nockfetchGoalInfo(this.goalNumber, {times: 2})
+
       const importedProject = await importProject(this.importData)
 
       expect(importedProject.goal.githubIssue.number).to.eq(this.goalNumber)
@@ -69,7 +67,6 @@ describe(testContext(__filename), function () {
       const newPlayers = await factory.createMany('player', {chapterId: this.chapter.id}, 4)
       const newGoalNumber = 2
 
-      useFixture.nockClean()
       useFixture.nockIDMfindUsers(newPlayers)
       useFixture.nockfetchGoalInfo(newGoalNumber)
 

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -146,9 +146,10 @@ export const useFixture = {
       }
     })
   },
-  nockIDMGetUsersById(users) {
+  nockIDMGetUsersById(users, {times = 1} = {}) {
     this.apiScope = nock(config.server.idm.baseURL)
       .post('/graphql')
+      .times(times)
       .reply(200, {
         data: {
           getUsersByIds: users,
@@ -159,18 +160,20 @@ export const useFixture = {
     nock.cleanAll()
     this.apiScope = null
   },
-  nockIDMfindUsers(users) {
+  nockIDMfindUsers(users, {times = 1} = {}) {
     this.apiScope = nock(config.server.idm.baseURL)
       .post('/graphql')
+      .times(times)
       .reply(200, {
         data: {
           findUsers: users,
         },
       })
   },
-  nockfetchGoalInfo(goalNumber) {
+  nockfetchGoalInfo(goalNumber, {times = 1} = {}) {
     this.apiScope = nock('https://api.github.com')
       .get(`/repos/GuildCraftsTesting/web-development-js-testing/issues/${goalNumber}`)
+      .times(times)
       .reply(200, {
         number: goalNumber,
         labels: [],


### PR DESCRIPTION
We were nocking 2 IDM calls before all tests but didn;t really need to
be. In fact, in the last test we needed to mock something else
altogether, so we were calling nockClean() and then re-nocking the IDM
calls with different values. With this change I'm just removing the
beforeEach nocking and instead just making sure that any nocks from
previous tests are cleared in the beforeEach. Then I'm adding the needed
nock calls to the one test that needs them. This test actually needed to
support multiple calls to the same IDM API, so I added that
functionality to the fixtures.