### PR TITLE
Refactoring graphql survey response mutations

### DIFF
--- a/server/actions/__tests__/saveSurveyResponses.test.js
+++ b/server/actions/__tests__/saveSurveyResponses.test.js
@@ -1,0 +1,38 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback */
+import {withDBCleanup, useFixture} from 'src/test/helpers'
+import factory from 'src/test/factories'
+import {Response} from 'src/server/services/dataService'
+
+import saveSurveyResponses from '../saveSurveyResponses'
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+  useFixture.buildSurvey()
+
+  beforeEach(async function () {
+    await this.buildSurvey()
+    const playerId = this.project.playerIds[0]
+    this.currentUser = await factory.build('user', {id: playerId})
+  })
+
+  it('create new responses and returns the ids', async function () {
+    const args = {
+      responses: [
+        {
+          respondentId: this.currentUser.id,
+          surveyId: this.survey.id,
+          questionId: this.surveyQuestion.id,
+          values: [{subjectId: this.survey.questionRefs[0].subjectIds[0], value: 'response'}],
+        }
+      ],
+      projectName: this.project.name
+    }
+
+    const [returnedResponseId] = await saveSurveyResponses(args)
+
+    const response = await Response.get(returnedResponseId)
+    return expect(response).to.exist
+  })
+})

--- a/server/actions/saveSurveyResponses.js
+++ b/server/actions/saveSurveyResponses.js
@@ -1,39 +1,9 @@
 import Promise from 'bluebird'
-import {GraphQLError} from 'graphql/error'
 
-import {findActiveProjectReviewSurvey, getProjectByName} from 'src/server/db/project'
 import saveSurveyResponse from 'src/server/actions/saveSurveyResponse'
 import {flatten} from 'src/common/util'
 
-export default async function saveSurveyResponses({respondentId, responses, projectName}) {
-  let project
-  let survey
-  if (projectName) {
-    project = projectName ? await getProjectByName(projectName) : {}
-    survey = project ? await findActiveProjectReviewSurvey(project) : {}
-  }
-
-  const createdIdLists = await Promise.map(responses, async response => {
-    let surveyResponse
-    if (response.values) {
-      if (respondentId !== response.respondentId) {
-        throw new GraphQLError('You cannot submit responses for other players.')
-      }
-
-      surveyResponse = {...response, respondentId}
-    } else { // named question responses
-      const {questionName, responseParams} = response
-      const {questionId, subjectIds} = survey.questionRefs.find(ref => ref.name === questionName) || {}
-      surveyResponse = {
-        respondentId,
-        questionId,
-        surveyId: survey.id,
-        values: [{subjectId: subjectIds[0], value: responseParams[0]}]
-      }
-    }
-
-    return saveSurveyResponse(surveyResponse)
-  })
-
+export default async function saveSurveyResponses({responses}) {
+  const createdIdLists = await Promise.map(responses, saveSurveyResponse)
   return flatten(createdIdLists)
 }

--- a/server/db/__tests__/project.test.js
+++ b/server/db/__tests__/project.test.js
@@ -6,7 +6,6 @@ import {recordSurveyCompletedBy} from 'src/server/db/survey'
 import {
   findProjectByNameForPlayer,
   findProjectBySurveyId,
-  findActiveProjectReviewSurvey,
   findProjectsAndReviewResponsesForPlayer,
   getProjectByName,
   getProjectsForPlayer,
@@ -97,26 +96,6 @@ describe(testContext(__filename), function () {
       await factory.create('project', {name: 'projectName'})
       const promise = getProjectByName('anotherName')
       await expect(promise).to.eventually.be.rejectedWith('No project found')
-    })
-  })
-
-  describe('findActiveProjectReviewSurvey()', function () {
-    it('finds the right survey', async function () {
-      const projectWithoutSurvey = await factory.create('project')
-      const survey = await factory.create('survey')
-      const updatedProject = {
-        id: projectWithoutSurvey.id,
-        projectReviewSurveyId: survey.id,
-      }
-      const {changes: [{new_val: project}]} = await updateProject(updatedProject, {returnChanges: true})
-      const result = await findActiveProjectReviewSurvey(project)
-      expect(result.id).to.eq(survey.id)
-    })
-
-    it('resolves to undefined when no project found', async function () {
-      const project = await factory.create('project')
-      const result = await findActiveProjectReviewSurvey(project)
-      expect(result).to.be.undefined
     })
   })
 

--- a/server/db/project.js
+++ b/server/db/project.js
@@ -1,9 +1,7 @@
 import {connect} from 'src/db'
-import {REFLECTION} from 'src/common/models/cycle'
 
 import {customQueryError} from './errors'
 import {insertAllIntoTable, updateInTable} from './util'
-import {cyclesTable} from './cycle'
 import {getSurveyById} from './survey'
 import {getSurveyResponsesForPlayer} from './response'
 
@@ -93,20 +91,6 @@ export function update(project, options) {
   return updateInTable(project, table, options)
 }
 export const updateProject = update
-
-export async function findActiveProjectReviewSurvey(project) {
-  const projectCycle = await cyclesTable.get(project.cycleId)
-  if (!projectCycle) {
-    throw new Error(`Project ${project.id} has an invalid cycle ID ${project.cycleId}`)
-  }
-  if (projectCycle.state !== REFLECTION) {
-    return
-  }
-  if (!project.projectReviewSurveyId) {
-    return
-  }
-  return getSurveyById(project.projectReviewSurveyId)
-}
 
 export function findProjectsAndReviewResponsesForPlayer(chapterId, cycleId, playerId) {
   return findProjects({chapterId, cycleId})

--- a/server/graphql/mutations/__tests__/response.test.js
+++ b/server/graphql/mutations/__tests__/response.test.js
@@ -124,7 +124,7 @@ describe(testContext(__filename), function () {
     })
   })
 
-  describe('saveProjectReviewResponses', function () {
+  describe('saveProjectReviewCLISurveyResponses', function () {
     useFixture.createProjectReviewSurvey()
 
     beforeEach(async function () {

--- a/server/graphql/mutations/saveProjectReviewCLISurveyResponses.js
+++ b/server/graphql/mutations/saveProjectReviewCLISurveyResponses.js
@@ -2,7 +2,7 @@ import {GraphQLNonNull, GraphQLString} from 'graphql'
 import {GraphQLList} from 'graphql/type'
 
 import {CreatedIdList, CLINamedSurveyResponse} from 'src/server/graphql/schemas'
-import {resolveSaveSurveyResponses} from 'src/server/graphql/resolvers'
+import {resolveSaveProjectReviewCLISurveyResponses} from 'src/server/graphql/resolvers'
 
 export default {
   type: CreatedIdList,
@@ -17,6 +17,6 @@ export default {
     },
   },
   async resolve(source, {responses, projectName}, ast) {
-    return await resolveSaveSurveyResponses(source, {responses, projectName}, ast)
+    return await resolveSaveProjectReviewCLISurveyResponses(source, {responses, projectName}, ast)
   }
 }

--- a/server/graphql/queries/__tests__/survey.test.js
+++ b/server/graphql/queries/__tests__/survey.test.js
@@ -7,7 +7,7 @@ import nock from 'nock'
 import {connect} from 'src/db'
 import factory from 'src/test/factories'
 import {withDBCleanup, runGraphQLQuery, useFixture, mockIdmUsersById} from 'src/test/helpers'
-import saveSurveyResponses from 'src/server/actions/saveSurveyResponses'
+import {resolveSaveProjectReviewCLISurveyResponses} from 'src/server/graphql/resolvers'
 
 import fields from '../index'
 
@@ -210,11 +210,13 @@ describe(testContext(__filename), function () {
 
     describe('when the review is in progress', function () {
       beforeEach(function () {
-        return saveSurveyResponses({
-          respondentId: this.currentUser.id,
-          responses: [{questionName: 'A', responseParams: ['8']}],
-          projectName: this.project.name,
-        })
+        const responses = [{questionName: 'A', responseParams: ['8']}]
+        const projectName = this.project.name
+        return resolveSaveProjectReviewCLISurveyResponses(
+          null,
+          {responses, projectName},
+          {rootValue: {currentUser: this.currentUser}}
+        )
       })
 
       it('returns the status showing the review in progress', function () {
@@ -235,14 +237,16 @@ describe(testContext(__filename), function () {
 
     describe('when player has completed the review', function () {
       beforeEach(function () {
-        return saveSurveyResponses({
-          respondentId: this.currentUser.id,
-          responses: [
-            {questionName: 'A', responseParams: ['8']},
-            {questionName: 'B', responseParams: ['9']},
-          ],
-          projectName: this.project.name,
-        })
+        const responses = [
+          {questionName: 'A', responseParams: ['8']},
+          {questionName: 'B', responseParams: ['9']},
+        ]
+        const projectName = this.project.name
+        return resolveSaveProjectReviewCLISurveyResponses(
+          null,
+          {responses, projectName},
+          {rootValue: {currentUser: this.currentUser}}
+        )
       })
 
       it('returns the status showing the completed review', function () {

--- a/server/graphql/resolvers/__tests__/resolveSaveProjectReviewCLISurveyResponses.test.js
+++ b/server/graphql/resolvers/__tests__/resolveSaveProjectReviewCLISurveyResponses.test.js
@@ -1,0 +1,69 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback */
+import {withDBCleanup, useFixture, expectArraysToContainTheSameElements} from 'src/test/helpers'
+import factory from 'src/test/factories'
+import {Response} from 'src/server/services/dataService'
+
+import {resolveSaveProjectReviewCLISurveyResponses} from '../index'
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+  useFixture.createProjectReviewSurvey()
+
+  beforeEach(async function () {
+    await this.createProjectReviewSurvey()
+    const player = await factory.create('player', {chapterId: this.cycle.chapterId})
+    this.currentUser = await factory.build('user', {id: player.id})
+    this.ast = {rootValue: {currentUser: this.currentUser}}
+  })
+
+  describe('answering one at a time', function () {
+    it('saves the responses with the right attributes', async function () {
+      const args1 = {responses: [{questionName: 'A', responseParams: ['80'], respondentId: this.currentUser.id}], projectName: this.project.name}
+      const args2 = {responses: [{questionName: 'B', responseParams: ['75'], respondentId: this.currentUser.id}], projectName: this.project.name}
+      const {createdIds: [returnedResponseId1]} = await resolveSaveProjectReviewCLISurveyResponses(null, args1, this.ast)
+      const {createdIds: [returnedResponseId2]} = await resolveSaveProjectReviewCLISurveyResponses(null, args2, this.ast)
+
+      const responses = await Response.run()
+      expect(responses.length).to.eq(2)
+
+      const response1 = responses.find(({id}) => id === returnedResponseId1)
+      const response2 = responses.find(({id}) => id === returnedResponseId2)
+
+      expect(response1).to.have.property('value', 80)
+      expect(response1).to.have.property('questionId', this.questionA.id)
+      expect(response2).to.have.property('value', 75)
+      expect(response2).to.have.property('questionId', this.questionB.id)
+      responses.forEach(response => checkResponse(response, this.survey, this.currentUser, this.project))
+    })
+  })
+
+  describe('answering all questions at once', function () {
+    it('saves the responses with the right attributes', async function () {
+      const args = {
+        responses: [
+          {questionName: 'A', responseParams: ['80'], respondentId: this.currentUser.id},
+          {questionName: 'B', responseParams: ['75'], respondentId: this.currentUser.id},
+        ],
+        projectName: this.project.name
+      }
+      const {createdIds} = await resolveSaveProjectReviewCLISurveyResponses(null, args, this.ast)
+
+      const responses = await Response.run()
+      expect(responses.length).to.eq(2)
+      expectArraysToContainTheSameElements(createdIds, responses.map(({id}) => id))
+      expect(responses.find(response => response.questionId === this.questionA.id))
+        .to.have.property('value', 80)
+      expect(responses.find(response => response.questionId === this.questionB.id))
+        .to.have.property('value', 75)
+      responses.forEach(response => checkResponse(response, this.survey, this.currentUser, this.project))
+    })
+  })
+})
+
+function checkResponse(response, survey, respondent, subject) {
+  expect(response).to.have.property('surveyId', survey.id)
+  expect(response).to.have.property('respondentId', respondent.id)
+  expect(response.subjectId).to.eq(subject.id)
+}

--- a/server/graphql/resolvers/__tests__/resolveSaveSurveyResponses.test.js
+++ b/server/graphql/resolvers/__tests__/resolveSaveSurveyResponses.test.js
@@ -1,70 +1,61 @@
 /* eslint-env mocha */
 /* global expect, testContext */
 /* eslint-disable prefer-arrow-callback */
-import {connect} from 'src/db'
-import {withDBCleanup, useFixture, expectArraysToContainTheSameElements} from 'src/test/helpers'
+import {withDBCleanup, useFixture} from 'src/test/helpers'
 import factory from 'src/test/factories'
+import {Response} from 'src/server/services/dataService'
 
 import {resolveSaveSurveyResponses} from '../index'
 
-const r = connect()
-
 describe(testContext(__filename), function () {
   withDBCleanup()
-  useFixture.createProjectReviewSurvey()
+  useFixture.buildSurvey()
 
   beforeEach(async function () {
-    await this.createProjectReviewSurvey()
-    const player = await factory.create('player', {chapterId: this.cycle.chapterId})
-    this.currentUser = await factory.build('user', {id: player.id})
+    await this.buildSurvey()
+    const playerId = this.project.playerIds[0]
+    this.currentUser = await factory.build('user', {id: playerId})
+    this.ast = {rootValue: {currentUser: this.currentUser}}
   })
 
-  describe('answering one at a time', function () {
-    it('saves the responses with the right attributes', async function () {
-      const args1 = {responses: [{questionName: 'A', responseParams: ['80']}], projectName: this.project.name}
-      const args2 = {responses: [{questionName: 'B', responseParams: ['75']}], projectName: this.project.name}
-      const ast = {rootValue: {currentUser: this.currentUser}}
-      const {createdIds: [returnedResponseId1]} = await resolveSaveSurveyResponses(null, args1, ast)
-      const {createdIds: [returnedResponseId2]} = await resolveSaveSurveyResponses(null, args2, ast)
+  it('saves a response', async function () {
+    const args = _buildArgsWithResponse(this)
+    const {createdIds: [returnedResponseId]} = await resolveSaveSurveyResponses(null, args, this.ast)
 
-      const responses = await r.table('responses').run()
-      expect(responses.length).to.eq(2)
-
-      const response1 = responses.find(({id}) => id === returnedResponseId1)
-      const response2 = responses.find(({id}) => id === returnedResponseId2)
-
-      expect(response1).to.have.property('value', 80)
-      expect(response1).to.have.property('questionId', this.questionA.id)
-      expect(response2).to.have.property('value', 75)
-      expect(response2).to.have.property('questionId', this.questionB.id)
-      responses.forEach(response => checkResponse(response, this.survey, this.currentUser, this.project))
-    })
+    const response = await Response.get(returnedResponseId)
+    return expect(response).to.exist
   })
 
-  describe('answering all questions at once', function () {
-    it('saves the responses with the right attributes', async function () {
-      const responseData = [
-        {questionName: 'A', responseParams: ['80']},
-        {questionName: 'B', responseParams: ['75']},
-      ]
-      const args = {responses: responseData, projectName: this.project.name}
-      const ast = {rootValue: {currentUser: this.currentUser}}
-      const {createdIds} = await resolveSaveSurveyResponses(null, args, ast)
+  it('returns a rejected promise if a player tries to save responses for another player', async function () {
+    const otherPlayerId = this.project.playerIds[1]
+    const args = _buildArgsWithResponse(this, {respondentId: otherPlayerId})
 
-      const responses = await r.table('responses').run()
-      expect(responses.length).to.eq(2)
-      expectArraysToContainTheSameElements(createdIds, responses.map(({id}) => id))
-      expect(responses.find(response => response.questionId === this.questionA.id))
-        .to.have.property('value', 80)
-      expect(responses.find(response => response.questionId === this.questionB.id))
-        .to.have.property('value', 75)
-      responses.forEach(response => checkResponse(response, this.survey, this.currentUser, this.project))
-    })
+    await expect(
+      resolveSaveSurveyResponses(null, args, this.ast)
+    ).to.be.rejectedWith(/You cannot submit responses for other players/)
+  })
+
+  it('returns a rejected promise if the user does not have the correct role', async function () {
+    this.currentUser.roles = ['notTheRightRole']
+    const args = _buildArgsWithResponse(this)
+
+    await expect(
+      resolveSaveSurveyResponses(null, args, this.ast)
+    ).to.be.rejectedWith(/not authorized/)
   })
 })
 
-function checkResponse(response, survey, respondent, subject) {
-  expect(response).to.have.property('surveyId', survey.id)
-  expect(response).to.have.property('respondentId', respondent.id)
-  expect(response.subjectId).to.eq(subject.id)
+function _buildArgsWithResponse(test, responseOverrides) {
+  return {
+    responses: [
+      {
+        surveyId: test.survey.id,
+        questionId: test.surveyQuestion.id,
+        respondentId: test.currentUser.id,
+        values: [{subjectId: test.survey.questionRefs[0].subjectIds[0], value: 'response'}],
+        ...responseOverrides
+      }
+    ],
+    projectName: test.project.name
+  }
 }

--- a/server/graphql/resolvers/index.js
+++ b/server/graphql/resolvers/index.js
@@ -4,9 +4,11 @@ import {userCan} from 'src/common/util'
 import {REFLECTION} from 'src/common/models/cycle'
 import {getChapterById} from 'src/server/db/chapter'
 import {getCycleById} from 'src/server/db/cycle'
-import {getProjectById} from 'src/server/db/project'
+import {getProjectById, getProjectByName} from 'src/server/db/project'
+import {Survey} from 'src/server/services/dataService'
 import saveSurveyResponses from 'src/server/actions/saveSurveyResponses'
 import assertPlayersCurrentCycleInState from 'src/server/actions/assertPlayersCurrentCycleInState'
+import {BadInputError} from 'src/server/errors'
 import {handleError} from 'src/server/graphql/util'
 
 export async function resolveCycleChapter(cycle) {
@@ -45,15 +47,56 @@ export async function resolveSurveyProject(parent) {
   }
 }
 
-export async function resolveSaveSurveyResponses(source, {responses, projectName}, {rootValue: {currentUser}}) {
-  if (!currentUser || !userCan(currentUser, 'saveResponse')) {
-    throw new GraphQLError('You are not authorized to do that.')
-  }
-
+export async function resolveSaveSurveyResponses(source, {responses}, {rootValue: {currentUser}}) {
+  _assertUserAuthroized(currentUser, 'saveResponse')
   await assertPlayersCurrentCycleInState(currentUser, REFLECTION)
 
-  const createdIds = await saveSurveyResponses({respondentId: currentUser.id, responses, projectName})
-    .catch(err => handleError(err, 'Failed to save responses'))
+  return await _validateAndSaveResponses(responses, currentUser)
+}
 
-  return {createdIds}
+export async function resolveSaveProjectReviewCLISurveyResponses(source, {responses: namedResponses, projectName}, {rootValue: {currentUser}}) {
+  _assertUserAuthroized(currentUser, 'saveResponse')
+  await assertPlayersCurrentCycleInState(currentUser, REFLECTION)
+
+  const responses = await _buildResponsesFromNamedResponses(namedResponses, projectName, currentUser.id)
+
+  return await _validateAndSaveResponses(responses, currentUser)
+}
+
+function _assertUserAuthroized(user, action) {
+  if (!user || !userCan(user, action)) {
+    throw new GraphQLError('You are not authorized to do that.')
+  }
+}
+
+async function _validateAndSaveResponses(responses, currentUser) {
+  await _assertCurrentUserCanSubmitResponsesForRespodent(currentUser, responses)
+
+  return await saveSurveyResponses({responses})
+    .then(createdIds => ({createdIds}))
+    .catch(err => handleError(err, 'Failed to save responses'))
+}
+
+function _assertCurrentUserCanSubmitResponsesForRespodent(currentUser, responses) {
+  responses.forEach(response => {
+    if (currentUser.id !== response.respondentId) {
+      throw new BadInputError('You cannot submit responses for other players.')
+    }
+  })
+}
+
+async function _buildResponsesFromNamedResponses(namedResponses, projectName, respondentId) {
+  const project = await getProjectByName(projectName)
+  const survey = await Survey.get(project.projectReviewSurveyId)
+
+  return namedResponses.map(namedResponse => {
+    const {questionName, responseParams} = namedResponse
+    const {questionId, subjectIds} = survey.questionRefs.find(ref => ref.name === questionName) || {}
+    return {
+      respondentId,
+      questionId,
+      surveyId: survey.id,
+      values: [{subjectId: subjectIds[0], value: responseParams[0]}]
+    }
+  })
 }


### PR DESCRIPTION
## Overview

There's a bit of special logic needed to parse the
`saveProjectReviewCLISurveyResponses` API inputs and add in the extra context
that's missing. Previously this branch was triggering all of that logic
deeper in the stack in an action based on whether an individual response
had a 'values' attribute. Since the logic is primarily about handling
that particular API endpoints inputs I've moved the logic back into the
resolver layer with a custom resolver for that endpoint that calls a
helper to convert the sparse named responses received by that endpoint into
"full" responses with all of the context they need to be saved.

I've also moved some of the authentication checking closer to the API.
For example, checking to make sure that players don't submit responses
for others is now done in the resolver, not the action. This means we
could use this action in an admin interface where we might want to
submit responses for another user, or in a script where there's
no concept of a "current user" at all.

I also noticed that we were using `findActiveProjectReviewSurvey`
to get the "active" project review survey for a project. I suspect this
was a holdover from a time when the project data model supported a
project that spanned multiple cycles. Since that's not the case anymore
I switched to a simple thinky `Survey.get()` to get the survey by id and
removed the `findActiveProjectReviewSurvey` method which is no longer
used anywhere.