### PR TITLE
Admin Tools #4: GraphQL API Updates

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,11 +3,7 @@ engines:
   csslint:
     enabled: true
   duplication:
-    enabled: true
-    config:
-      languages:
-        javascript:
-          mass_threshold: 100
+    enabled: false
   eslint:
     enabled: false
   fixme:
@@ -18,12 +14,7 @@ ratings:
   - "**.inc"
   - "**.js"
   - "**.jsx"
-  - "**.module"
-  - "**.php"
-  - "**.py"
-  - "**.rb"
-# exclude_paths:
-# - config/
-# - db/
-# - test/
-# - scripts/
+exclude_paths:
+- node_modules/
+- test/
+- "__tests__/"

--- a/common/util/format.js
+++ b/common/util/format.js
@@ -1,0 +1,36 @@
+import {
+  AsYouTypeFormatter,
+  PhoneNumberFormat,
+  PhoneNumberUtil
+} from 'google-libphonenumber'
+
+const phoneUtil = PhoneNumberUtil.getInstance()
+
+export function formatPartialPhoneNumber(str, countryCode = 'US') {
+  if (!str) {
+    return ''
+  }
+  const formatter = new AsYouTypeFormatter(countryCode)
+  formatter.clear()
+  let formatted
+  str.toString().split('').forEach(d => {
+    formatted = formatter.inputDigit(d)
+  })
+  return formatted
+}
+
+export function stripNonE164Chars(str) {
+  if (!str) {
+    return ''
+  }
+  return str.toString().replace(/[^+\d]/g, '')
+}
+
+export function phoneNumberAsE164(str, countryCode = 'US') {
+  const phoneDigits = stripNonE164Chars(str)
+  if (phoneDigits.length < 10) {
+    throw new Error('Phone numbers must be at least 10 digits.')
+  }
+  const phoneNumber = phoneUtil.parse(phoneDigits, countryCode)
+  return phoneUtil.format(phoneNumber, PhoneNumberFormat.E164)
+}

--- a/common/util/userCan.js
+++ b/common/util/userCan.js
@@ -47,8 +47,37 @@ const CAPABILITY_ROLES = {
     'moderator',
   ],
 
+  listProjects: [
+    'backoffice',
+    'moderator',
+    'player',
+  ],
   updateProject: [
     'player',
+    'moderator',
+  ],
+  viewProject: [
+    'backoffice',
+    'moderator',
+    'player',
+  ],
+  viewProjectSummary: [
+    'backoffice',
+    'moderator',
+  ],
+
+  listUsers: [
+    'backoffice',
+    'moderator',
+    'player',
+  ],
+  viewUser: [
+    'backoffice',
+    'moderator',
+    'player',
+  ],
+  viewUserSummary: [
+    'backoffice',
     'moderator',
   ],
 
@@ -68,9 +97,11 @@ const CAPABILITY_ROLES = {
     'player',
     'backoffice',
   ],
+
   runReports: [
     'backoffice'
   ],
+
   monitorJobQueues: [
     'backoffice',
   ],

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -23,6 +23,7 @@ if (config.app.hotReload) {
 /** vendor entry points */
 if (config.app.minify) {
   entry.vendor = [
+    'google-libphonenumber',
     'juration',
     'moment-timezone',
     'raven-js',
@@ -180,6 +181,10 @@ const loaders = [
   },
 ]
 
+const noParse = [
+  /node_modules\/google-libphonenumber\/dist/,
+]
+
 module.exports = {
   entry,
   output,
@@ -187,7 +192,7 @@ module.exports = {
   resolve,
   plugins,
   context: ROOT_DIR,
-  module: {loaders},
+  module: {loaders, noParse},
   postcss: [autoprefixer],
   sassResources: './config/sass-resources.scss',
   sassLoader: {data: `@import "${path.resolve(__dirname, '..', 'common', 'theme.scss')}";`},

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1299,7 +1299,8 @@
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
-          "from": "object-assign@>=4.1.0 <5.0.0"
+          "from": "object-assign@4.1.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
@@ -2988,6 +2989,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
         }
       }
+    },
+    "google-libphonenumber": {
+      "version": "2.0.6",
+      "from": "google-libphonenumber@latest",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-2.0.6.tgz"
     },
     "got": {
       "version": "5.6.0",
@@ -6580,7 +6586,8 @@
     },
     "rethinkdb-changefeed-reconnect": {
       "version": "0.3.1",
-      "from": "rethinkdb-changefeed-reconnect@latest"
+      "from": "rethinkdb-changefeed-reconnect@0.3.1",
+      "resolved": "https://registry.npmjs.org/rethinkdb-changefeed-reconnect/-/rethinkdb-changefeed-reconnect-0.3.1.tgz"
     },
     "rethinkdbdash": {
       "version": "2.3.25",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "express-sslify": "^1.0.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
+    "google-libphonenumber": "^2.0.6",
     "graphql": "^0.4.18",
     "graphql-custom-types": "^0.3.0",
     "history": "^2.0.0",

--- a/scripts/runStats.js
+++ b/scripts/runStats.js
@@ -80,9 +80,7 @@ async function run() {
 function setPlayerStats(player, stats) {
   console.log(LOG_PREFIX, `Setting stats for player ${player.id}`)
 
-  return Player.get(player.id)
-    .update({stats})
-    .run()
+  return Player.get(player.id).update({stats})
 }
 
 async function updateChapterStats(chapter) {

--- a/server/actions/__tests__/findActivePlayersInChapter.test.js
+++ b/server/actions/__tests__/findActivePlayersInChapter.test.js
@@ -4,7 +4,7 @@
 import {truncateDBTables, useFixture} from 'src/test/helpers'
 import factory from 'src/test/factories'
 
-import getActivePlayersInChapter from 'src/server/actions/getActivePlayersInChapter'
+import findActivePlayersInChapter from 'src/server/actions/findActivePlayersInChapter'
 
 describe(testContext(__filename), function () {
   before(truncateDBTables)
@@ -16,7 +16,7 @@ describe(testContext(__filename), function () {
     users[0].active = users[1].active = false
     useFixture.nockIDMGetUsersById(users)
 
-    const activePlayers = await getActivePlayersInChapter(chapter.id)
+    const activePlayers = await findActivePlayersInChapter(chapter.id)
 
     expect(activePlayers.length).to.equal(8)
   })

--- a/server/actions/__tests__/findProjectReviews.test.js
+++ b/server/actions/__tests__/findProjectReviews.test.js
@@ -1,0 +1,44 @@
+/* eslint-env mocha */
+/* global expect testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions, max-nested-callbacks */
+import Promise from 'bluebird'
+
+import factory from 'src/test/factories'
+import {truncateDBTables, useFixture} from 'src/test/helpers'
+
+import findProjectReviews from '../findProjectReviews'
+
+describe(testContext(__filename), function () {
+  before(truncateDBTables)
+
+  before(async function () {
+    useFixture.nockClean()
+    useFixture.createProjectReviewSurvey()
+    this.players = await factory.createMany('player', 5)
+  })
+
+  it('returns correct reviews for project', async function () {
+    await this.createProjectReviewSurvey()
+
+    const sortedPlayers = this.players.sort((p1, p2) => p1.id.localeCompare(p2.id))
+
+    await Promise.mapSeries(sortedPlayers, (player, i) => {
+      const response = {surveyId: this.survey.id, respondentId: player.id, subjectId: this.project.id}
+      return Promise.all([
+        factory.create('response', {...response, questionId: this.questionCompleteness.id, value: 80 + i}),
+        factory.create('response', {...response, questionId: this.questionQuality.id, value: 90 + i}),
+      ])
+    })
+
+    const reviews = await findProjectReviews(this.project.id)
+    const sortedReviews = reviews.sort((r1, r2) => r1.submittedById.localeCompare(r2.submittedById))
+
+    expect(reviews.length).to.eq(sortedPlayers.length)
+
+    sortedReviews.forEach((review, i) => {
+      expect(review.submittedById).to.eq(sortedPlayers[i].id)
+      expect(review.completeness).to.eq(80 + i)
+      expect(review.quality).to.eq(90 + i)
+    })
+  })
+})

--- a/server/actions/__tests__/findUserProjectReviews.test.js
+++ b/server/actions/__tests__/findUserProjectReviews.test.js
@@ -1,0 +1,78 @@
+/* eslint-env mocha */
+/* global expect testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions, max-nested-callbacks */
+import Promise from 'bluebird'
+
+import factory from 'src/test/factories'
+import {truncateDBTables, useFixture} from 'src/test/helpers'
+import {Project} from 'src/server/services/dataService'
+import {STAT_DESCRIPTORS} from 'src/common/models/stat'
+
+import findUserProjectReviews from '../findUserProjectReviews'
+
+describe(testContext(__filename), function () {
+  before(truncateDBTables)
+
+  before(function () {
+    useFixture.nockClean()
+  })
+
+  beforeEach(async function () {
+    const project = await factory.create('project')
+    const questions = []
+    const questionRefs = []
+    await Promise.each([
+      STAT_DESCRIPTORS.CHALLENGE,
+      STAT_DESCRIPTORS.TEAM_PLAY,
+      STAT_DESCRIPTORS.TECHNICAL_HEALTH,
+    ], async statDescriptor => {
+      const stat = await factory.create('stat', {descriptor: statDescriptor})
+      const question = await factory.create('question', {
+        statId: stat.id,
+        body: statDescriptor,
+        subjectType: 'player',
+        responseType: 'text',
+      })
+      questions.push(question)
+      project.playerIds.forEach(subjectId => {
+        questionRefs.push({subjectIds: [subjectId], questionId: question.id})
+      })
+    })
+    const retrospectiveSurvey = await factory.create('survey', {questionRefs})
+    await Project.get(project.id).update({retrospectiveSurveyId: retrospectiveSurvey.id})
+    this.project = await Project.get(project.id)
+    this.questions = questions
+    this.survey = retrospectiveSurvey
+  })
+
+  it('returns correct reviews for user on project', async function () {
+    const {questions, project} = this
+    const {playerIds} = project
+
+    await Promise.map(playerIds, async subjectId => {
+      await Promise.each(playerIds, async respondentId => {
+        if (respondentId !== subjectId) {
+          await Promise.each(questions, question => (
+            factory.create('response', {
+              respondentId,
+              subjectId,
+              surveyId: this.survey.id,
+              questionId: question.id,
+              value: `${question.body}_${respondentId}`,
+            })
+          ))
+        }
+      })
+
+      const userProjectReviews = await findUserProjectReviews(subjectId, project)
+
+      expect(userProjectReviews.length).to.eq(playerIds.length - 1)
+      userProjectReviews.forEach(review => {
+        const respondentId = review.submittedById
+        expect(review.challenge).to.eq(`${STAT_DESCRIPTORS.CHALLENGE}_${respondentId}`)
+        expect(review.teamPlay).to.eq(`${STAT_DESCRIPTORS.TEAM_PLAY}_${respondentId}`)
+        expect(review.technical).to.eq(`${STAT_DESCRIPTORS.TECHNICAL_HEALTH}_${respondentId}`)
+      })
+    })
+  })
+})

--- a/server/actions/__tests__/findUsers.test.js
+++ b/server/actions/__tests__/findUsers.test.js
@@ -1,0 +1,82 @@
+/* eslint-env mocha */
+/* global expect testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions, max-nested-callbacks */
+import factory from 'src/test/factories'
+import {truncateDBTables, useFixture} from 'src/test/helpers'
+import {expectArraysToContainTheSameElements} from 'src/test/helpers/expectations'
+
+import findUsers from '../findUsers'
+
+describe(testContext(__filename), function () {
+  before(truncateDBTables)
+  before(async function () {
+    this.players = await factory.createMany('player', 5)
+    this.users = this.players.map(player => ({
+      id: player.id,
+      handle: `handle_${player.id}`,
+    }))
+  })
+  beforeEach(function () {
+    useFixture.nockClean()
+  })
+
+  describe('findUsers()', function () {
+    it('returns correct users for handle identifiers', async function () {
+      const users = this.users.slice(0, 2)
+      useFixture.nockIDMFindUsers(users)
+      const result = await findUsers(users.map(u => u.handle))
+      expectArraysToContainTheSameElements(result.map(u => u.id), users.map(u => u.id))
+    })
+
+    it('returns correct users for UUIDs', async function () {
+      const users = this.players.slice(0, 5)
+      useFixture.nockIDMFindUsers(users)
+      const result = await findUsers(users.map(u => u.id))
+      expectArraysToContainTheSameElements(result.map(u => u.id), users.map(u => u.id))
+    })
+
+    it('returns only unique users', async function () {
+      const user = this.users[0]
+      const {id, handle} = user
+      useFixture.nockIDMFindUsers([user, user])
+      const result = await findUsers([id, handle])
+      expect(result.length).to.equal(1)
+    })
+
+    it('returns all IDM fields if none specified', async function () {
+      useFixture.nockIDMFindUsers(this.users)
+      const user = this.users[0]
+      const player = this.players.find(p => p.id === user.id)
+      const [result] = await findUsers([user.id])
+      expect(result.id).to.equal(user.id)
+      expect(result.handle).to.equal(user.handle)
+      expect(result.name).to.equal(user.name)
+      expect(result.email).to.equal(user.email)
+      expect(result.chapterId).to.equal(player.chapterId)
+    })
+
+    it('returns only specified IDM fields', async function () {
+      useFixture.nockIDMFindUsers(this.users)
+      const user = this.users[0]
+      const idmFields = ['handle']
+      const [result] = await findUsers([user.id], {idmFields})
+      expect(result.id).to.equal(user.id)
+      expect(result.handle).to.equal(user.handle)
+      expect(result.name).to.not.exist
+      expect(result.email).to.not.exist
+    })
+
+    it('returns all users if no identifiers specified', async function () {
+      useFixture.nockIDMFindUsers(this.users)
+      const result = await findUsers()
+      expect(result.length).to.equal(this.users.length)
+      expectArraysToContainTheSameElements(result.map(u => u.id), this.users.map(p => p.id))
+    })
+
+    it('returns no users if no matching identifiers specified', async function () {
+      useFixture.nockIDMFindUsers([])
+      const result = await findUsers([this.users[0].id])
+      expect(result.length).to.equal(0)
+    })
+  })
+})

--- a/server/actions/__tests__/getUser.test.js
+++ b/server/actions/__tests__/getUser.test.js
@@ -1,0 +1,38 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+import factory from 'src/test/factories'
+import {withDBCleanup, useFixture} from 'src/test/helpers'
+
+import getUser from '../getUser'
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+
+  beforeEach(function () {
+    useFixture.nockClean()
+  })
+
+  it('returns correct user for identifier', async function () {
+    const user = await factory.build('user')
+    const player = await factory.create('player', {id: user.id})
+    await factory.createMany('player', 2) // extra players
+
+    useFixture.nockIDMGetUser(user)
+
+    const result = await getUser(user.id)
+    expect(result.id).to.equal(user.id)
+    expect(result.handle).to.equal(user.handle)
+    expect(result.email).to.equal(user.email)
+    expect(result.avatarUrl).to.equal(user.avatarUrl)
+    expect(result.profileUrl).to.equal(user.profileUrl)
+    expect(result.chapterId).to.equal(player.chapterId)
+  })
+
+  it('returns null if user exists in IDM but not in game', async function () {
+    const user = await factory.build('user')
+    useFixture.nockIDMGetUser(user)
+    const result = await getUser(user.id)
+    return expect(result).to.not.exist
+  })
+})

--- a/server/actions/__tests__/importProject.test.js
+++ b/server/actions/__tests__/importProject.test.js
@@ -1,8 +1,10 @@
+
 /* eslint-env mocha */
 /* global expect testContext */
 /* eslint-disable prefer-arrow-callback, no-unused-expressions, max-nested-callbacks */
 import factory from 'src/test/factories'
 import {truncateDBTables, useFixture} from 'src/test/helpers'
+import {expectArraysToContainTheSameElements} from 'src/test/helpers/expectations'
 import {GOAL_SELECTION} from 'src/common/models/cycle'
 
 import importProject from '../importProject'
@@ -47,28 +49,23 @@ describe(testContext(__filename), function () {
     })
 
     it('creates a new project a projectIdentifier is not specified', async function () {
-      useFixture.nockIDMfindUsers(this.users)
-      useFixture.nockfetchGoalInfo(this.goalNumber, {times: 2})
-
+      useFixture.nockIDMFindUsers(this.users)
+      useFixture.nockFetchGoalInfo(this.goalNumber, {times: 2})
       const importedProject = await importProject(this.importData)
 
       expect(importedProject.goal.githubIssue.number).to.eq(this.goalNumber)
       expect(importedProject.chapterId).to.eq(this.chapter.id)
       expect(importedProject.cycleId).to.eq(this.cycle.id)
-      expect(
-        importedProject.playerIds.sort()
-      ).to.deep.eq(
-        this.players.map(p => p.id).sort()
-      )
+      expectArraysToContainTheSameElements(importedProject.playerIds, this.players.map(p => p.id))
     })
 
-    it('updates goal and users when a valid projectIdentifier is specified', async function () {
+    it('updates goal and users when a valid project identifier is specified', async function () {
       const newProject = await factory.create('project', {chapterId: this.chapter.id, cycleId: this.cycle.id})
       const newPlayers = await factory.createMany('player', {chapterId: this.chapter.id}, 4)
       const newGoalNumber = 2
 
-      useFixture.nockIDMfindUsers(newPlayers)
-      useFixture.nockfetchGoalInfo(newGoalNumber)
+      useFixture.nockIDMFindUsers(newPlayers)
+      useFixture.nockFetchGoalInfo(newGoalNumber)
 
       const importedProject = await importProject({
         ...this.importData,
@@ -82,9 +79,7 @@ describe(testContext(__filename), function () {
       expect(importedProject.cycleId).to.eq(this.cycle.id)
       expect(importedProject.playerIds.length).to.eq(newPlayers.length)
       expect(importedProject.goal.githubIssue.number).to.eq(newGoalNumber)
-      importedProject.playerIds.forEach(playerId => {
-        expect(newPlayers.find(p => p.id === playerId))
-      })
+      expectArraysToContainTheSameElements(importedProject.playerIds, newPlayers.map(p => p.id))
     })
   })
 })

--- a/server/actions/createPoolsForCycle.js
+++ b/server/actions/createPoolsForCycle.js
@@ -2,7 +2,7 @@ import Promise from 'bluebird'
 import {savePools, addPlayerIdsToPool} from 'src/server/db/pool'
 import {flatten} from 'src/common/util'
 import {shuffle, range} from 'src/server/util'
-import getActivePlayersInChapter from 'src/server/actions/getActivePlayersInChapter'
+import findActivePlayersInChapter from 'src/server/actions/findActivePlayersInChapter'
 
 const MAX_POOL_SIZE = 15
 /* eslint-disable key-spacing */
@@ -32,7 +32,7 @@ const POOL_NAMES = [
 ]
 
 export default async function createPoolsForCycle(cycle) {
-  const players = await getActivePlayersInChapter(cycle.chapterId)
+  const players = await findActivePlayersInChapter(cycle.chapterId)
   const poolAssignments = _splitPlayersIntoPools(players)
   const poolCount = poolAssignments.length
 

--- a/server/actions/findActivePlayersInChapter.js
+++ b/server/actions/findActivePlayersInChapter.js
@@ -2,7 +2,7 @@ import {findPlayersForChapter} from 'src/server/db/player'
 import {mapById} from 'src/server/util'
 import getPlayerInfo from './getPlayerInfo'
 
-export default async function getActivePlayersInChapter(chapterId) {
+export default async function findActivePlayersInChapter(chapterId) {
   const players = await findPlayersForChapter(chapterId)
   const playerIds = players.map(_ => _.id)
   const idmActiveUsers = (await getPlayerInfo(playerIds)).filter(_ => _.active)

--- a/server/actions/findProjectReviews.js
+++ b/server/actions/findProjectReviews.js
@@ -1,0 +1,48 @@
+import {Response, Project} from 'src/server/services/dataService'
+import {groupById} from 'src/server/util'
+import {findValueForReponseQuestionStat} from 'src/server/util/stats'
+import {STAT_DESCRIPTORS} from 'src/common/models/stat'
+
+const {PROJECT_COMPLETENESS, PROJECT_QUALITY} = STAT_DESCRIPTORS
+
+export default async function findProjectReviews(projectIdentifier) {
+  const project = await (typeof projectIdentifier === 'string' ?
+    Project.get(projectIdentifier) :
+    projectIdentifier
+  )
+
+  if (!project || !project.id) {
+    throw new Error(`Project not found for identifier: ${projectIdentifier}`)
+  }
+
+  const {projectReviewSurveyId} = project
+  if (!projectReviewSurveyId) {
+    return []
+  }
+
+  const reviewSurveyResponses = groupById(
+    await Response.filter({
+      surveyId: projectReviewSurveyId,
+      subjectId: project.id,
+    })
+    .getJoin({question: {stat: true}})
+  , 'respondentId')
+
+  const projectReviews = []
+  reviewSurveyResponses.forEach((responses, respondentId) => {
+    // choose create time of earliest response as create time for the "review"
+    const createdAt = responses.sort((r1, r2) => {
+      const diff = r1.createdAt.getTime() - r2.createdAt.getTime()
+      return diff === 0 ? r1.id.localeCompare(r2.id) : diff
+    })[0].createdAt
+
+    projectReviews.push({
+      createdAt,
+      submittedById: respondentId,
+      completeness: findValueForReponseQuestionStat(responses, PROJECT_COMPLETENESS),
+      quality: findValueForReponseQuestionStat(responses, PROJECT_QUALITY),
+    })
+  })
+
+  return projectReviews
+}

--- a/server/actions/findUserProjectReviews.js
+++ b/server/actions/findUserProjectReviews.js
@@ -1,0 +1,68 @@
+import {Response, Player, Project} from 'src/server/services/dataService'
+import {groupById} from 'src/server/util'
+import {findValueForReponseQuestionStat} from 'src/server/util/stats'
+import {STAT_DESCRIPTORS} from 'src/common/models/stat'
+
+const {
+  CHALLENGE,
+  CULTURE_CONTRIBUTION,
+  FLEXIBLE_LEADERSHIP,
+  FRICTION_REDUCTION,
+  GENERAL_FEEDBACK,
+  RECEPTIVENESS,
+  RELATIVE_CONTRIBUTION,
+  RESULTS_FOCUS,
+  TECHNICAL_HEALTH,
+  TEAM_PLAY,
+} = STAT_DESCRIPTORS
+
+export default async function findUserProjectReviews(userIdentifier, projectIdentifier) {
+  const user = await (typeof userIdentifier === 'string' ? Player.get(userIdentifier) : userIdentifier)
+  if (!user || !user.id) {
+    throw new Error(`User not found for identifier: ${userIdentifier}`)
+  }
+
+  const project = await (typeof projectIdentifier === 'string' ? Project.get(projectIdentifier) : projectIdentifier)
+  if (!project || !project.id) {
+    throw new Error(`Project not found for identifier: ${projectIdentifier}`)
+  }
+
+  const {retrospectiveSurveyId} = project
+  if (!retrospectiveSurveyId) {
+    return []
+  }
+
+  const retroSurveyResponses = groupById(
+    await Response.filter({
+      surveyId: retrospectiveSurveyId,
+      subjectId: user.id,
+    })
+    .getJoin({question: {stat: true}})
+  , 'respondentId')
+
+  const userProjectReviews = []
+  retroSurveyResponses.forEach((responses, respondentId) => {
+    // choose create time of earliest response as create time for the "review"
+    const createdAt = responses.sort((r1, r2) => {
+      const diff = r1.createdAt.getTime() - r2.createdAt.getTime()
+      return diff === 0 ? r1.id.localeCompare(r2.id) : diff
+    })[0].createdAt
+
+    userProjectReviews.push({
+      createdAt,
+      submittedById: respondentId,
+      challenge: findValueForReponseQuestionStat(responses, CHALLENGE),
+      contribution: findValueForReponseQuestionStat(responses, RELATIVE_CONTRIBUTION),
+      culture: findValueForReponseQuestionStat(responses, CULTURE_CONTRIBUTION),
+      focus: findValueForReponseQuestionStat(responses, RESULTS_FOCUS),
+      friction: findValueForReponseQuestionStat(responses, FRICTION_REDUCTION),
+      general: findValueForReponseQuestionStat(responses, GENERAL_FEEDBACK),
+      leadership: findValueForReponseQuestionStat(responses, FLEXIBLE_LEADERSHIP),
+      receptiveness: findValueForReponseQuestionStat(responses, RECEPTIVENESS),
+      teamPlay: findValueForReponseQuestionStat(responses, TEAM_PLAY),
+      technical: findValueForReponseQuestionStat(responses, TECHNICAL_HEALTH),
+    })
+  })
+
+  return userProjectReviews
+}

--- a/server/actions/findUsers.js
+++ b/server/actions/findUsers.js
@@ -2,7 +2,13 @@ import config from 'src/config'
 import mergeUsers from 'src/server/actions/mergeUsers'
 import {graphQLFetcher} from 'src/server/util/graphql'
 
-export default function findUsers(identifiers, idmFields) {
+const defaultIdmFields = [
+  'id', 'name', 'handle', 'email', 'phone', 'avatarUrl',
+  'profileUrl', 'timezone', 'active', 'roles', 'inviteCode'
+]
+
+export default function findUsers(identifiers, options) {
+  const {idmFields = defaultIdmFields} = options || {}
   const queryFields = Array.isArray(idmFields) ? idmFields.join(', ') : idmFields
 
   return graphQLFetcher(config.server.idm.baseURL)({

--- a/server/actions/getUser.js
+++ b/server/actions/getUser.js
@@ -1,14 +1,20 @@
 import config from 'src/config'
-import mergeUsers from 'src/actions/mergeUsers'
+import mergeUsers from 'src/server/actions/mergeUsers'
 import {graphQLFetcher} from 'src/server/util/graphql'
 
-export default function getUser(identifier, idmFields) {
+const defaultIdmFields = [
+  'id', 'name', 'handle', 'email', 'phone', 'avatarUrl',
+  'profileUrl', 'timezone', 'active', 'roles', 'inviteCode'
+]
+
+export default function getUser(identifier, options) {
+  const {idmFields = defaultIdmFields} = options || {}
   const queryFields = Array.isArray(idmFields) ? idmFields.join(', ') : idmFields
 
   return graphQLFetcher(config.server.idm.baseURL)({
     query: `query ($identifier: String!) {getUser(identifier: $identifier) {${queryFields}}}`,
     variables: {identifier},
   })
-  .then(result => mergeUsers([result.data.getUser], {skipNoMatch: true}))
+  .then(result => (result.data.getUser ? mergeUsers([result.data.getUser], {skipNoMatch: true}) : []))
   .then(users => users[0])
 }

--- a/server/actions/importProject.js
+++ b/server/actions/importProject.js
@@ -49,11 +49,9 @@ async function _parseProjectInput(data) {
     userIdentifiers,
   } = data || {}
 
-  const userFields = ['id', 'handle']
-
   const [chapter, users] = await Promise.all([
     getChapter(chapterIdentifier),
-    userIdentifiers ? findUsers(userIdentifiers, userFields) : null,
+    userIdentifiers ? findUsers(userIdentifiers, {idmFields: ['id', 'handle']}) : null,
   ])
 
   if (!chapter) {

--- a/server/actions/mergeUsers.js
+++ b/server/actions/mergeUsers.js
@@ -15,14 +15,14 @@ export default async function mergeUsers(users, options) {
   const players = mapById(await findPlayersByIds(userIds))
   const moderators = mapById(await findModeratorsByIds(userIds))
 
-  return users.reduce((result, user) => {
+  return Object.values(users.reduce((result, user) => {
     const gameUser = players.get(user.id) || moderators.get(user.id)
-    if (gameUser && skipNoMatch) {
+    if (gameUser) {
       // only return in results if user has a game account
-      result.push(Object.assign({}, user, gameUser))
-    } else {
+      result[user.id] = Object.assign({}, user, gameUser)
+    } else if (!skipNoMatch) {
       throw new Error(`User not found for id ${user.id}, user merge aborted`)
     }
     return result
-  }, [])
+  }, {}))
 }

--- a/server/graphql/mutations/__tests__/response.test.js
+++ b/server/graphql/mutations/__tests__/response.test.js
@@ -134,8 +134,8 @@ describe(testContext(__filename), function () {
 
       this.invokeAPI = function (projectName = this.project.name, responses) {
         responses = responses || [
-          {questionName: 'A', responseParams: ['80']},
-          {questionName: 'B', responseParams: ['75']},
+          {questionName: 'completeness', responseParams: ['80']},
+          {questionName: 'quality', responseParams: ['75']},
         ]
         return runGraphQLMutation(
           `mutation($projectName: String!, $responses: [CLINamedSurveyResponse]!) {
@@ -158,7 +158,7 @@ describe(testContext(__filename), function () {
 
     it('returns helpful error messages for invalid values', function () {
       return expect(
-        this.invokeAPI(this.project.name, [{questionName: 'A', responseParams: ['101']}])
+        this.invokeAPI(this.project.name, [{questionName: 'completeness', responseParams: ['101']}])
       ).to.be.rejectedWith(/must be less than or equal to 100/)
     })
 

--- a/server/graphql/queries/__tests__/findProjects.test.js
+++ b/server/graphql/queries/__tests__/findProjects.test.js
@@ -1,0 +1,71 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+import factory from 'src/test/factories'
+import {withDBCleanup, runGraphQLQuery} from 'src/test/helpers'
+import {expectArraysToContainTheSameElements} from 'src/test/helpers/expectations'
+import {Project} from 'src/server/services/dataService'
+
+import fields from '../index'
+
+const query = `
+  query($identifiers: [String]) {
+    findProjects(identifiers: $identifiers) {
+      id
+      chapter { id }
+      cycle { id }
+    }
+  }
+`
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+
+  beforeEach('Create current user', async function () {
+    this.currentUser = await factory.build('user')
+    this.projects = await factory.createMany('project', 3)
+  })
+
+  it('returns correct projects for identifiers', async function () {
+    const project = this.projects[0]
+    const result = await runGraphQLQuery(
+      query,
+      fields,
+      {identifiers: [project.id]},
+      {currentUser: this.currentUser},
+    )
+    const returnedProjects = result.data.findProjects
+    const returnedProject = returnedProjects[0]
+    expect(returnedProjects.length).to.equal(1)
+    expect(returnedProject.id).to.equal(project.id)
+    expect(returnedProject.chapter.id).to.equal(project.chapterId)
+    expect(returnedProject.cycle.id).to.equal(project.cycleId)
+  })
+
+  it('returns all projects if no identifiers specified', async function () {
+    const allProjects = await Project.run()
+    const {data: {findProjects: result}} = await runGraphQLQuery(
+      query,
+      fields,
+      null,
+      {currentUser: this.currentUser},
+    )
+    expect(result.length).to.equal(allProjects.length)
+    expectArraysToContainTheSameElements(allProjects.map(p => p.id), result.map(p => p.id))
+  })
+
+  it('returns no projects if no matching identifiers specified', async function () {
+    const result = await runGraphQLQuery(
+      query,
+      fields,
+      {identifiers: ['']},
+      {currentUser: this.currentUser},
+    )
+    expect(result.data.findProjects.length).to.equal(0)
+  })
+
+  it('throws an error if user is not signed-in', function () {
+    const result = runGraphQLQuery(query, fields, null, {currentUser: null})
+    return expect(result).to.eventually.be.rejectedWith(/not authorized/i)
+  })
+})

--- a/server/graphql/queries/__tests__/findUsers.test.js
+++ b/server/graphql/queries/__tests__/findUsers.test.js
@@ -1,0 +1,50 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+import factory from 'src/test/factories'
+import {withDBCleanup, runGraphQLQuery, useFixture} from 'src/test/helpers'
+
+import fields from '../index'
+
+const query = `
+  query($identifiers: [String]) {
+    findUsers(identifiers: $identifiers) {
+      id name handle avatarUrl
+      chapter { id name }
+    }
+  }
+`
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+
+  beforeEach('Create current user', async function () {
+    this.currentUser = await factory.build('user')
+    this.users = await factory.buildMany('user', 3)
+    this.player = await factory.create('player', {id: this.users[0].id})
+    await factory.createMany('player', 5) // extra players
+  })
+
+  it('returns correct users with resolved chapters for identifiers', async function () {
+    const player = this.player
+    const user = this.users[0]
+    useFixture.nockIDMFindUsers([user])
+    const result = await runGraphQLQuery(
+      query,
+      fields,
+      {identifiers: [player.id]},
+      {currentUser: this.currentUser},
+    )
+    expect(result.data.findUsers.length).to.equal(1)
+    const [returned] = result.data.findUsers
+    expect(returned.id).to.equal(user.id)
+    expect(returned.name).to.equal(user.name)
+    expect(returned.avatarUrl).to.equal(user.avatarUrl)
+    expect(returned.chapter.id).to.equal(player.chapterId)
+  })
+
+  it('throws an error if user is not signed-in', function () {
+    const result = runGraphQLQuery(query, fields, null, {currentUser: null})
+    return expect(result).to.eventually.be.rejectedWith(/not authorized/i)
+  })
+})

--- a/server/graphql/queries/__tests__/getProject.test.js
+++ b/server/graphql/queries/__tests__/getProject.test.js
@@ -1,0 +1,57 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+import factory from 'src/test/factories'
+import {withDBCleanup, runGraphQLQuery} from 'src/test/helpers'
+
+import fields from '../index'
+
+const query = `
+  query($identifier: String!) {
+    getProject(identifier: $identifier) {
+      id
+      chapter { id }
+      cycle { id }
+      goal { number title level url }
+      stats { hours completeness quality }
+    }
+  }
+`
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+
+  beforeEach('Create current user', async function () {
+    this.currentUser = await factory.build('user')
+  })
+
+  it('returns correct project for identifier', async function () {
+    const projects = await factory.createMany('project', 2)
+    const project = projects[0]
+    const result = await runGraphQLQuery(
+      query,
+      fields,
+      {identifier: project.id},
+      {currentUser: this.currentUser},
+    )
+    const returnedProject = result.data.getProject
+    expect(returnedProject.id).to.equal(project.id)
+    expect(returnedProject.chapter.id).to.equal(project.chapterId)
+    expect(returnedProject.cycle.id).to.equal(project.cycleId)
+  })
+
+  it('throws an error if project is not found', function () {
+    const result = runGraphQLQuery(
+      query,
+      fields,
+      {identifier: ''},
+      {currentUser: this.currentUser},
+    )
+    return expect(result).to.eventually.be.rejectedWith(/Project not found/i)
+  })
+
+  it('throws an error if user is not signed-in', function () {
+    const result = runGraphQLQuery(query, fields, {identifier: ''}, {currentUser: null})
+    return expect(result).to.eventually.be.rejectedWith(/not authorized/i)
+  })
+})

--- a/server/graphql/queries/__tests__/getProjectSummary.test.js
+++ b/server/graphql/queries/__tests__/getProjectSummary.test.js
@@ -1,0 +1,73 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+import Promise from 'bluebird'
+
+import factory from 'src/test/factories'
+import {withDBCleanup, runGraphQLQuery, useFixture} from 'src/test/helpers'
+
+import fields from '../index'
+
+const query = `
+  query($identifier: String!) {
+    getProjectSummary(identifier: $identifier) {
+      project { id chapter { id } }
+      projectReviews {
+        completeness
+        quality
+        submittedBy { id handle }
+      }
+      projectUserSummaries {
+        user { id handle }
+        userProjectReviews {
+          contribution
+          technical
+          culture
+          submittedBy { id handle }
+        }
+        userProjectStats { rating xp }
+      }
+    }
+  }
+`
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+
+  beforeEach('Create current user', async function () {
+    this.currentUser = await factory.build('user', {roles: ['moderator']})
+    this.users = await factory.buildMany('user', 3)
+    this.project = await factory.create('project', {playerIds: this.users.map(u => u.id)})
+    await Promise.each(this.users, user => (
+      factory.create('player', {id: user.id})
+    ))
+  })
+
+  it('returns correct summary for project identifier', async function () {
+    useFixture.nockIDMFindUsers(this.users)
+    const result = await runGraphQLQuery(
+      query,
+      fields,
+      {identifier: this.project.id},
+      {currentUser: this.currentUser},
+    )
+    const returned = result.data.getProjectSummary
+    expect(returned.project.id).to.equal(this.project.id)
+    expect(returned.project.chapter.id).to.equal(this.project.chapterId)
+  })
+
+  it('throws an error if project is not found', function () {
+    const result = runGraphQLQuery(
+      query,
+      fields,
+      {identifier: ''},
+      {currentUser: this.currentUser},
+    )
+    return expect(result).to.eventually.be.rejectedWith(/Project not found/i)
+  })
+
+  it('throws an error if user is not signed-in', function () {
+    const result = runGraphQLQuery(query, fields, {identifier: ''}, {currentUser: null})
+    return expect(result).to.eventually.be.rejectedWith(/not authorized/i)
+  })
+})

--- a/server/graphql/queries/__tests__/getUser.test.js
+++ b/server/graphql/queries/__tests__/getUser.test.js
@@ -1,0 +1,62 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+import factory from 'src/test/factories'
+import {withDBCleanup, runGraphQLQuery, useFixture} from 'src/test/helpers'
+
+import fields from '../index'
+
+const query = `
+  query($identifier: String!) {
+    getUser(identifier: $identifier) {
+      id name handle email avatarUrl profileUrl
+      chapter { id name }
+    }
+  }
+`
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+
+  beforeEach('Create current user', async function () {
+    this.currentUser = await factory.build('user')
+  })
+
+  it('returns correct user with chapter for identifier', async function () {
+    const user = await factory.build('user')
+    const player = await factory.create('player', {id: user.id})
+    await factory.createMany('player', 2) // extra players
+
+    useFixture.nockIDMGetUser(user)
+
+    const result = await runGraphQLQuery(
+      query,
+      fields,
+      {identifier: user.handle},
+      {currentUser: this.currentUser},
+    )
+    const returned = result.data.getUser
+    expect(returned.id).to.equal(user.id)
+    expect(returned.handle).to.equal(user.handle)
+    expect(returned.email).to.equal(user.email)
+    expect(returned.avatarUrl).to.equal(user.avatarUrl)
+    expect(returned.profileUrl).to.equal(user.profileUrl)
+    expect(returned.chapter.id).to.equal(player.chapterId)
+  })
+
+  it('throws an error if user is not found', function () {
+    useFixture.nockIDMGetUser(null)
+    const result = runGraphQLQuery(
+      query,
+      fields,
+      {identifier: 'fake.identifier'},
+      {currentUser: this.currentUser},
+    )
+    return expect(result).to.eventually.be.rejectedWith(/User not found/i)
+  })
+
+  it('throws an error if user is not signed-in', function () {
+    const result = runGraphQLQuery(query, fields, {identifier: ''}, {currentUser: null})
+    return expect(result).to.eventually.be.rejectedWith(/not authorized/i)
+  })
+})

--- a/server/graphql/queries/__tests__/getUserSummary.test.js
+++ b/server/graphql/queries/__tests__/getUserSummary.test.js
@@ -1,0 +1,73 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+import factory from 'src/test/factories'
+import {withDBCleanup, runGraphQLQuery, useFixture} from 'src/test/helpers'
+
+import fields from '../index'
+
+const query = `
+  query($identifier: String!) {
+    getUserSummary(identifier: $identifier) {
+      user {
+        id handle
+        chapter { id }
+      }
+      userProjectSummaries {
+        project { id name }
+        userProjectReviews {
+          contribution
+          technical
+          culture
+          submittedBy { id name handle }
+        }
+        userProjectStats { rating xp }
+      }
+    }
+  }
+`
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+
+  beforeEach('Create current user', async function () {
+    this.currentUser = await factory.build('user', {roles: ['moderator']})
+    this.user = await factory.build('user')
+  })
+
+  it('returns correct summary for user identifier', async function () {
+    useFixture.nockIDMGetUser(this.user)
+    const player = await factory.create('player', {id: this.user.id})
+    const result = await runGraphQLQuery(
+      query,
+      fields,
+      {identifier: player.id},
+      {currentUser: this.currentUser},
+    )
+    const returned = result.data.getUserSummary
+    expect(returned.user.id).to.equal(this.user.id)
+    expect(returned.user.handle).to.equal(this.user.handle)
+    expect(returned.user.chapter.id).to.equal(player.chapterId)
+  })
+
+  it('throws an error if user is not found', function () {
+    useFixture.nockIDMGetUser(this.user)
+    const result = runGraphQLQuery(
+      query,
+      fields,
+      {identifier: ''},
+      {currentUser: this.currentUser},
+    )
+    return expect(result).to.eventually.be.rejectedWith(/User not found/i)
+  })
+
+  it('throws an error if user is not signed-in', function () {
+    const result = runGraphQLQuery(
+      query,
+      fields,
+      {identifier: ''},
+      {currentUser: null}
+    )
+    return expect(result).to.eventually.be.rejectedWith(/not authorized/i)
+  })
+})

--- a/server/graphql/queries/__tests__/survey.test.js
+++ b/server/graphql/queries/__tests__/survey.test.js
@@ -210,7 +210,7 @@ describe(testContext(__filename), function () {
 
     describe('when the review is in progress', function () {
       beforeEach(function () {
-        const responses = [{questionName: 'A', responseParams: ['8']}]
+        const responses = [{questionName: 'completeness', responseParams: ['8']}]
         const projectName = this.project.name
         return resolveSaveProjectReviewCLISurveyResponses(
           null,
@@ -228,7 +228,7 @@ describe(testContext(__filename), function () {
               artifactURL: this.project.artifactURL
             },
             responses: [
-              {questionName: 'A', values: [{subjectId: this.project.id, value: '8'}]}
+              {questionName: 'completeness', values: [{subjectId: this.project.id, value: '8'}]}
             ],
           })
         })
@@ -238,8 +238,8 @@ describe(testContext(__filename), function () {
     describe('when player has completed the review', function () {
       beforeEach(function () {
         const responses = [
-          {questionName: 'A', responseParams: ['8']},
-          {questionName: 'B', responseParams: ['9']},
+          {questionName: 'completeness', responseParams: ['8']},
+          {questionName: 'quality', responseParams: ['9']},
         ]
         const projectName = this.project.name
         return resolveSaveProjectReviewCLISurveyResponses(
@@ -258,8 +258,8 @@ describe(testContext(__filename), function () {
               artifactURL: this.project.artifactURL
             },
             responses: [
-              {questionName: 'A', values: [{subjectId: this.project.id, value: '8'}]},
-              {questionName: 'B', values: [{subjectId: this.project.id, value: '9'}]},
+              {questionName: 'completeness', values: [{subjectId: this.project.id, value: '8'}]},
+              {questionName: 'quality', values: [{subjectId: this.project.id, value: '9'}]},
             ],
           })
         })

--- a/server/graphql/queries/findProjects.js
+++ b/server/graphql/queries/findProjects.js
@@ -1,0 +1,20 @@
+import {GraphQLString} from 'graphql'
+import {GraphQLError} from 'graphql/error'
+import {GraphQLList} from 'graphql/type'
+
+import {userCan} from 'src/common/util'
+import {findProjects} from 'src/server/db/project'
+import {Project} from 'src/server/graphql/schemas'
+
+export default {
+  type: new GraphQLList(Project),
+  args: {
+    identifiers: {type: new GraphQLList(GraphQLString), description: 'A list of project identifiers'},
+  },
+  async resolve(source, args = {}, {rootValue: {currentUser}}) {
+    if (!userCan(currentUser, 'listProjects')) {
+      throw new GraphQLError('You are not authorized to do that')
+    }
+    return findProjects(args.identifiers)
+  },
+}

--- a/server/graphql/queries/findUsers.js
+++ b/server/graphql/queries/findUsers.js
@@ -1,0 +1,21 @@
+import {GraphQLString} from 'graphql'
+import {GraphQLList} from 'graphql/type'
+import {GraphQLError} from 'graphql/error'
+
+import {userCan} from 'src/common/util'
+import findUsers from 'src/server/actions/findUsers'
+import {UserProfile} from 'src/server/graphql/schemas'
+
+export default {
+  type: new GraphQLList(UserProfile),
+  args: {
+    identifiers: {type: new GraphQLList(GraphQLString)},
+  },
+  async resolve(source, {identifiers}, {rootValue: {currentUser}}) {
+    if (!userCan(currentUser, 'listUsers')) {
+      throw new GraphQLError('You are not authorized to do that.')
+    }
+
+    return await findUsers(identifiers)
+  }
+}

--- a/server/graphql/queries/getProject.js
+++ b/server/graphql/queries/getProject.js
@@ -1,0 +1,25 @@
+import {GraphQLNonNull, GraphQLString} from 'graphql'
+import {GraphQLError} from 'graphql/error'
+
+import {userCan} from 'src/common/util'
+import {getProject} from 'src/server/db/project'
+import {Project} from 'src/server/graphql/schemas'
+
+export default {
+  type: Project,
+  args: {
+    identifier: {type: new GraphQLNonNull(GraphQLString), description: 'The project ID or name'}
+  },
+  async resolve(source, {identifier}, {rootValue: {currentUser}}) {
+    if (!userCan(currentUser, 'viewProject')) {
+      throw new GraphQLError('You are not authorized to do that')
+    }
+
+    const project = await getProject(identifier)
+    if (!project) {
+      throw new GraphQLError(`Project not found for identifier ${identifier}`)
+    }
+
+    return project
+  },
+}

--- a/server/graphql/queries/getProjectSummary.js
+++ b/server/graphql/queries/getProjectSummary.js
@@ -1,0 +1,25 @@
+import {GraphQLNonNull, GraphQLString} from 'graphql'
+import {GraphQLError} from 'graphql/error'
+
+import {userCan} from 'src/common/util'
+import {getProject} from 'src/server/db/project'
+import {ProjectSummary} from 'src/server/graphql/schemas'
+
+export default {
+  type: ProjectSummary,
+  args: {
+    identifier: {type: new GraphQLNonNull(GraphQLString), description: 'Project id or name'},
+  },
+  async resolve(source, {identifier}, {rootValue: {currentUser}}) {
+    if (!userCan(currentUser, 'viewProjectSummary')) {
+      throw new GraphQLError('You are not authorized to do that.')
+    }
+
+    const project = await getProject(identifier)
+    if (!project) {
+      throw new GraphQLError(`Project not found for identifier ${identifier}`)
+    }
+
+    return {project}
+  }
+}

--- a/server/graphql/queries/getProjectSummaryForPlayer.js
+++ b/server/graphql/queries/getProjectSummaryForPlayer.js
@@ -2,7 +2,7 @@ import {GraphQLError} from 'graphql/error'
 
 import {getLatestCycleForChapter} from 'src/server/db/cycle'
 import {getUserById} from 'src/server/db/user'
-import {getProjectsForPlayer, findProjects} from 'src/server/db/project'
+import {findProjectsForUser, findProjects} from 'src/server/db/project'
 import {ProjectsSummary} from 'src/server/graphql/schemas'
 
 export default {
@@ -16,7 +16,7 @@ export default {
     const cycle = await getLatestCycleForChapter(user.chapter.id)
 
     const numActiveProjectsForCycle = await findProjects({chapterId: user.chapter.id, cycleId: cycle.id}).count()
-    const numTotalProjectsForPlayer = await getProjectsForPlayer(user.id).count()
+    const numTotalProjectsForPlayer = await findProjectsForUser(user.id).count()
 
     return {numActiveProjectsForCycle, numTotalProjectsForPlayer}
   },

--- a/server/graphql/queries/getUser.js
+++ b/server/graphql/queries/getUser.js
@@ -1,0 +1,12 @@
+import {GraphQLNonNull, GraphQLString} from 'graphql'
+
+import {resolveGetUser} from 'src/server/graphql/resolvers'
+import {UserProfile} from 'src/server/graphql/schemas'
+
+export default {
+  type: UserProfile,
+  args: {
+    identifier: {type: new GraphQLNonNull(GraphQLString), description: 'The user ID or handle'},
+  },
+  resolve: resolveGetUser,
+}

--- a/server/graphql/queries/getUserSummary.js
+++ b/server/graphql/queries/getUserSummary.js
@@ -1,0 +1,23 @@
+import {GraphQLNonNull, GraphQLString} from 'graphql'
+import {GraphQLError} from 'graphql/error'
+
+import {userCan} from 'src/common/util'
+import {resolveGetUser} from 'src/server/graphql/resolvers'
+import {UserSummary} from 'src/server/graphql/schemas'
+
+export default {
+  type: UserSummary,
+  args: {
+    identifier: {type: new GraphQLNonNull(GraphQLString), description: 'The user ID or handle'},
+  },
+  async resolve(source, args, ast) {
+    const {rootValue: {currentUser}} = ast
+    if (!userCan(currentUser, 'viewUserSummary')) {
+      throw new GraphQLError('You are not authorized to do that.')
+    }
+
+    return {
+      user: await resolveGetUser(source, args, ast),
+    }
+  }
+}

--- a/server/graphql/resolvers/__tests__/resolveSaveProjectReviewCLISurveyResponses.test.js
+++ b/server/graphql/resolvers/__tests__/resolveSaveProjectReviewCLISurveyResponses.test.js
@@ -20,8 +20,8 @@ describe(testContext(__filename), function () {
 
   describe('answering one at a time', function () {
     it('saves the responses with the right attributes', async function () {
-      const args1 = {responses: [{questionName: 'A', responseParams: ['80'], respondentId: this.currentUser.id}], projectName: this.project.name}
-      const args2 = {responses: [{questionName: 'B', responseParams: ['75'], respondentId: this.currentUser.id}], projectName: this.project.name}
+      const args1 = {responses: [{questionName: 'completeness', responseParams: ['80'], respondentId: this.currentUser.id}], projectName: this.project.name}
+      const args2 = {responses: [{questionName: 'quality', responseParams: ['75'], respondentId: this.currentUser.id}], projectName: this.project.name}
       const {createdIds: [returnedResponseId1]} = await resolveSaveProjectReviewCLISurveyResponses(null, args1, this.ast)
       const {createdIds: [returnedResponseId2]} = await resolveSaveProjectReviewCLISurveyResponses(null, args2, this.ast)
 
@@ -32,9 +32,9 @@ describe(testContext(__filename), function () {
       const response2 = responses.find(({id}) => id === returnedResponseId2)
 
       expect(response1).to.have.property('value', 80)
-      expect(response1).to.have.property('questionId', this.questionA.id)
+      expect(response1).to.have.property('questionId', this.questionCompleteness.id)
       expect(response2).to.have.property('value', 75)
-      expect(response2).to.have.property('questionId', this.questionB.id)
+      expect(response2).to.have.property('questionId', this.questionQuality.id)
       responses.forEach(response => checkResponse(response, this.survey, this.currentUser, this.project))
     })
   })
@@ -43,8 +43,8 @@ describe(testContext(__filename), function () {
     it('saves the responses with the right attributes', async function () {
       const args = {
         responses: [
-          {questionName: 'A', responseParams: ['80'], respondentId: this.currentUser.id},
-          {questionName: 'B', responseParams: ['75'], respondentId: this.currentUser.id},
+          {questionName: 'completeness', responseParams: ['80'], respondentId: this.currentUser.id},
+          {questionName: 'quality', responseParams: ['75'], respondentId: this.currentUser.id},
         ],
         projectName: this.project.name
       }
@@ -53,9 +53,9 @@ describe(testContext(__filename), function () {
       const responses = await Response.run()
       expect(responses.length).to.eq(2)
       expectArraysToContainTheSameElements(createdIds, responses.map(({id}) => id))
-      expect(responses.find(response => response.questionId === this.questionA.id))
+      expect(responses.find(response => response.questionId === this.questionCompleteness.id))
         .to.have.property('value', 80)
-      expect(responses.find(response => response.questionId === this.questionB.id))
+      expect(responses.find(response => response.questionId === this.questionQuality.id))
         .to.have.property('value', 75)
       responses.forEach(response => checkResponse(response, this.survey, this.currentUser, this.project))
     })

--- a/server/graphql/resolvers/index.js
+++ b/server/graphql/resolvers/index.js
@@ -1,71 +1,224 @@
+import Promise from 'bluebird'
 import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import {REFLECTION} from 'src/common/models/cycle'
-import {getChapterById} from 'src/server/db/chapter'
-import {getCycleById} from 'src/server/db/cycle'
-import {getProjectById, getProjectByName} from 'src/server/db/project'
-import {Survey} from 'src/server/services/dataService'
+import {getProjectByName, findActiveProjectsForChapter, findProjectsForUser} from 'src/server/db/project'
 import saveSurveyResponses from 'src/server/actions/saveSurveyResponses'
 import assertPlayersCurrentCycleInState from 'src/server/actions/assertPlayersCurrentCycleInState'
-import {BadInputError} from 'src/server/errors'
+import {getLatestCycleForChapter} from 'src/server/db/cycle'
+import findActivePlayersInChapter from 'src/server/actions/findActivePlayersInChapter'
+import findProjectReviews from 'src/server/actions/findProjectReviews'
+import findUsers from 'src/server/actions/findUsers'
+import findUserProjectReviews from 'src/server/actions/findUserProjectReviews'
+import getUser from 'src/server/actions/getUser'
+import {Chapter, Cycle, Project, Survey} from 'src/server/services/dataService'
 import {handleError} from 'src/server/graphql/util'
+import {BadInputError} from 'src/server/errors'
+import {mapById} from 'src/server/util'
 
-export async function resolveCycleChapter(cycle) {
-  if (cycle.chapter) {
-    return cycle.chapter
+export async function resolveGetUser(source, {identifier}, {rootValue: {currentUser}}) {
+  if (!userCan(currentUser, 'viewUser')) {
+    throw new GraphQLError('You are not authorized to do that.')
   }
-  if (cycle.chapterId) {
-    return await getChapterById(cycle.chapterId)
+  const user = await getUser(identifier)
+  if (!user) {
+    throw new GraphQLError(`User not found for identifier ${identifier}`)
+  }
+  return user
+}
+
+export function resolveChapter(parent) {
+  return parent.chapter || _safeResolveAsync(
+    Chapter
+      .get(parent.chapterId || null)
+      .default(null)
+  )
+}
+
+export function resolveChapterLatestCycle(chapter) {
+  return chapter.latestCycle || _safeResolveAsync(
+    getLatestCycleForChapter(chapter.id, {default: null})
+  )
+}
+
+export function resolveChapterActiveProjectCount(chapter) {
+  return isNaN(chapter.activeProjectCount) ?
+    _safeResolveAsync(
+      findActiveProjectsForChapter(chapter.id, {count: true})
+    ) : chapter.activeProjectCount
+}
+
+export function resolveChapterActivePlayerCount(chapter) {
+  return isNaN(chapter.activePlayerCount) ?
+    _safeResolveAsync(
+      findActivePlayersInChapter(chapter.id, {count: true})
+    ) : chapter.activePlayerCount
+}
+
+export function resolveCycle(parent) {
+  return parent.cycle || _safeResolveAsync(
+    Cycle.get(parent.cycleId || null)
+  )
+}
+
+export function resolveProject(parent) {
+  return parent.project || _safeResolveAsync(
+    Project
+      .get(parent.projectId || null)
+      .default(null)
+  )
+}
+
+export function resolveProjectGoal(project) {
+  if (!project.goal) {
+    return null
+  }
+  const {githubIssue} = project.goal
+  if (!githubIssue) {
+    return project.goal
+  }
+  return {
+    number: githubIssue.number,
+    url: githubIssue.url,
+    title: githubIssue.title,
   }
 }
 
-export async function resolveProjectChapter(project) {
-  if (project.chapter) {
-    return project.chapter
+export function resolveProjectStats(project) {
+  if (project.stats) {
+    return project.stats
   }
-  if (project.chapterId) {
-    return await getChapterById(project.chapterId)
-  }
-}
-
-export async function resolveProjectCycle(project) {
-  if (project.cycle) {
-    return project.cycle
-  }
-  if (project.cycleId) {
-    return await getCycleById(project.cycleId)
+  return {
+    hours: null,
+    completeness: null,
+    quaity: null,
   }
 }
 
-export async function resolveSurveyProject(parent) {
-  if (parent.project) {
-    return parent.project
+export async function resolveProjectReviews(projectSummary) {
+  const {project} = projectSummary
+  if (!project) {
+    throw new Error('Invalid project for user summaries')
   }
-  if (parent.projectId) {
-    return await getProjectById(parent.projectId)
+  if (projectSummary.projectReviews) {
+    return projectSummary.projectReviews
+  }
+
+  return _mapUsers(
+    await findProjectReviews(project),
+    'submittedById',
+    'submittedBy'
+  )
+}
+
+export async function resolveProjectUserSummaries(projectSummary) {
+  const {project} = projectSummary
+  if (!project) {
+    throw new Error('Invalid project for user summaries')
+  }
+  if (projectSummary.projectUserSummaries) {
+    return projectSummary.projectUserSummaries
+  }
+
+  const users = await findUsers(project.playerIds)
+  return Promise.map(users, async user => {
+    const summary = await getUserProjectSummary(user, project)
+    return {user, ...summary}
+  })
+}
+
+export async function resolveUserProjectSummaries(userSummary) {
+  const {user} = userSummary
+  if (!user) {
+    throw new Error('Invalid user for project summaries')
+  }
+  if (userSummary.userProjectSummaries) {
+    return userSummary.userProjectSummaries
+  }
+
+  const projects = await findProjectsForUser(user.id)
+  return Promise.map(projects, async project => {
+    const summary = await getUserProjectSummary(user, project)
+    return {project, ...summary}
+  })
+}
+
+async function getUserProjectSummary(user, project) {
+  return {
+    userProjectStats: extractUserProjectStats(user, project),
+    userProjectReviews: await _mapUsers(
+      await findUserProjectReviews(user, project),
+      'submittedById',
+      'submittedBy',
+    ),
+  }
+}
+
+export function extractUserProjectStats(user, project) {
+  if (!user) {
+    throw new Error(`Invalid user ${user}`)
+  }
+  if (!project) {
+    throw new Error(`Invalid project ${project}`)
+  }
+
+  const stats = user.stats || {}
+  const projects = stats.projects || {}
+  const projectStats = projects[project.id] || {}
+  const rating = (projectStats.elo || {}).rating
+  const contribution = {
+    self: projectStats.rcSelf,
+    perHour: projectStats.rcPerHour,
+    other: projectStats.rcOther,
+    estimated: projectStats.rc,
+    expected: projectStats.ec,
+    delta: projectStats.ecd,
+  }
+
+  return {
+    rating,
+    contribution,
+    userId: user.id,
+    project: project.id,
+    xp: projectStats.xp,
+    hours: projectStats.hours,
+    challenge: projectStats.challenge,
+    culture: projectStats.cc,
+    technical: projectStats.th,
+    teamPlay: projectStats.teamPlay,
+    receptiveness: projectStats.receptiveness,
+    focus: projectStats.resultsFocus,
+    leadership: projectStats.flexibleLeadership,
+    friction: projectStats.frictionReduction,
   }
 }
 
 export async function resolveSaveSurveyResponses(source, {responses}, {rootValue: {currentUser}}) {
-  _assertUserAuthroized(currentUser, 'saveResponse')
+  _assertUserAuthorized(currentUser, 'saveResponse')
   await assertPlayersCurrentCycleInState(currentUser, REFLECTION)
-
   return await _validateAndSaveResponses(responses, currentUser)
 }
 
 export async function resolveSaveProjectReviewCLISurveyResponses(source, {responses: namedResponses, projectName}, {rootValue: {currentUser}}) {
-  _assertUserAuthroized(currentUser, 'saveResponse')
+  _assertUserAuthorized(currentUser, 'saveResponse')
   await assertPlayersCurrentCycleInState(currentUser, REFLECTION)
-
   const responses = await _buildResponsesFromNamedResponses(namedResponses, projectName, currentUser.id)
-
   return await _validateAndSaveResponses(responses, currentUser)
 }
 
-function _assertUserAuthroized(user, action) {
-  if (!user || !userCan(user, action)) {
-    throw new GraphQLError('You are not authorized to do that.')
+export function resolveUserStats(user, args, {rootValue: {currentUser}}) {
+  if (user.id !== currentUser.id && !userCan(currentUser, 'viewUserStats')) {
+    return null
+  }
+  if (user.stats && 'rating' in user.stats) {
+    return user.stats
+  }
+
+  const userStats = user.stats || {}
+  return {
+    rating: (userStats.elo || {}).rating,
+    xp: userStats.xp,
   }
 }
 
@@ -99,4 +252,33 @@ async function _buildResponsesFromNamedResponses(namedResponses, projectName, re
       values: [{subjectId: subjectIds[0], value: responseParams[0]}]
     }
   })
+}
+
+function _assertUserAuthorized(user, action) {
+  if (!user || !userCan(user, action)) {
+    throw new GraphQLError('You are not authorized to do that.')
+  }
+}
+
+async function _mapUsers(collection, userIdKey = 'userId', userKey = 'user') {
+  if (!collection || collection.length === 0) {
+    return []
+  }
+
+  const userIds = collection.map(item => item[userIdKey])
+  const usersById = mapById(await findUsers(userIds))
+  collection.forEach(item => {
+    item[userKey] = usersById.get(item[userIdKey])
+  })
+
+  return collection
+}
+
+async function _safeResolveAsync(query) {
+  try {
+    return await query
+  } catch (err) {
+    console.error(err)
+    return null
+  }
 }

--- a/server/graphql/schemas/Goal.js
+++ b/server/graphql/schemas/Goal.js
@@ -1,14 +1,16 @@
-import {GraphQLString, GraphQLNonNull} from 'graphql'
+import {GraphQLString, GraphQLInt, GraphQLNonNull} from 'graphql'
 import {GraphQLObjectType} from 'graphql/type'
 import {GraphQLURL} from 'graphql-custom-types'
 
 export default new GraphQLObjectType({
   name: 'Goal',
-  description: 'A potential Project to work on',
+  description: 'A goal for a project team to work on',
   fields: () => {
     return {
-      url: {type: new GraphQLNonNull(GraphQLURL), description: 'The Goal URL'},
-      title: {type: GraphQLString, description: 'The Goal Title'},
+      number: {type: new GraphQLNonNull(GraphQLInt), description: 'The goal number'},
+      url: {type: new GraphQLNonNull(GraphQLURL), description: 'The goal URL'},
+      title: {type: GraphQLString, description: 'The goal title'},
+      level: {type: GraphQLString, description: 'The goal level'},
     }
   },
 })

--- a/server/graphql/schemas/Project.js
+++ b/server/graphql/schemas/Project.js
@@ -2,22 +2,29 @@ import {GraphQLNonNull, GraphQLID, GraphQLString} from 'graphql'
 import {GraphQLURL, GraphQLDateTime} from 'graphql-custom-types'
 import {GraphQLObjectType} from 'graphql/type'
 
-import {resolveProjectChapter, resolveProjectCycle} from 'src/server/graphql/resolvers'
+import {
+  resolveChapter,
+  resolveCycle,
+  resolveProjectGoal,
+  resolveProjectStats,
+} from 'src/server/graphql/resolvers'
 
 export default new GraphQLObjectType({
   name: 'Project',
   description: 'A project engaged in by learners to complete some goal',
   fields: () => {
-    const {Chapter, Cycle} = require('src/server/graphql/schemas')
+    const {Chapter, Cycle, Goal, ProjectStats} = require('src/server/graphql/schemas')
 
     return {
       id: {type: new GraphQLNonNull(GraphQLID), description: "The project's UUID"},
       name: {type: new GraphQLNonNull(GraphQLString), description: 'The project name'},
+      chapter: {type: Chapter, description: 'The chapter', resolve: resolveChapter},
+      cycle: {type: Cycle, description: 'The cycle', resolve: resolveCycle},
+      goal: {type: Goal, description: 'The project goal', resolve: resolveProjectGoal},
+      stats: {type: ProjectStats, description: 'The project stats', resolve: resolveProjectStats},
       artifactURL: {type: GraphQLURL, description: 'The URL pointing to the output of this project'},
       createdAt: {type: new GraphQLNonNull(GraphQLDateTime), description: 'When this record was created'},
       updatedAt: {type: new GraphQLNonNull(GraphQLDateTime), description: 'When this record was last updated'},
-      chapter: {type: Chapter, description: 'The chapter', resolve: resolveProjectChapter},
-      cycle: {type: Cycle, description: 'The cycle', resolve: resolveProjectCycle},
     }
   },
 })

--- a/server/graphql/schemas/ProjectReview.js
+++ b/server/graphql/schemas/ProjectReview.js
@@ -1,0 +1,18 @@
+import {GraphQLFloat} from 'graphql'
+import {GraphQLObjectType} from 'graphql/type'
+import {GraphQLDateTime} from 'graphql-custom-types'
+
+export default new GraphQLObjectType({
+  name: 'ProjectReview',
+  description: 'A project review',
+  fields: () => {
+    const {UserProfile} = require('src/server/graphql/schemas')
+
+    return {
+      submittedBy: {type: UserProfile, description: 'The review submitter'},
+      completeness: {type: GraphQLFloat, description: 'The completeness rating'},
+      quality: {type: GraphQLFloat, description: 'The quality rating'},
+      createdAt: {type: GraphQLDateTime, description: 'The datetime of the review creation'},
+    }
+  },
+})

--- a/server/graphql/schemas/ProjectStats.js
+++ b/server/graphql/schemas/ProjectStats.js
@@ -1,0 +1,14 @@
+import {GraphQLFloat} from 'graphql'
+import {GraphQLObjectType} from 'graphql/type'
+
+export default new GraphQLObjectType({
+  name: 'ProjectStats',
+  description: 'A project\'s stats',
+  fields: () => {
+    return {
+      hours: {type: GraphQLFloat, description: 'Total hours worked by all members'},
+      quality: {type: GraphQLFloat, description: 'Quality score (avg.)'},
+      completeness: {type: GraphQLFloat, description: 'Completeness score (avg.)'},
+    }
+  }
+})

--- a/server/graphql/schemas/ProjectSummary.js
+++ b/server/graphql/schemas/ProjectSummary.js
@@ -1,0 +1,21 @@
+import {GraphQLNonNull} from 'graphql'
+import {GraphQLObjectType, GraphQLList} from 'graphql/type'
+
+import {
+  resolveProjectReviews,
+  resolveProjectUserSummaries,
+} from 'src/server/graphql/resolvers'
+
+export default new GraphQLObjectType({
+  name: 'ProjectSummary',
+  description: 'Summary of project details',
+  fields: () => {
+    const {Project, ProjectReview, ProjectUserSummary} = require('src/server/graphql/schemas')
+
+    return {
+      project: {type: new GraphQLNonNull(Project), description: 'The project'},
+      projectReviews: {type: new GraphQLList(ProjectReview), resolve: resolveProjectReviews, description: 'The project\'s reviews'},
+      projectUserSummaries: {type: new GraphQLList(ProjectUserSummary), resolve: resolveProjectUserSummaries, description: 'The project\'s user summaries'},
+    }
+  }
+})

--- a/server/graphql/schemas/ProjectUserSummary.js
+++ b/server/graphql/schemas/ProjectUserSummary.js
@@ -1,0 +1,16 @@
+import {GraphQLNonNull} from 'graphql'
+import {GraphQLObjectType, GraphQLList} from 'graphql/type'
+
+export default new GraphQLObjectType({
+  name: 'ProjectUserSummary',
+  description: 'Project user summary',
+  fields: () => {
+    const {UserProfile, UserProjectStats, UserProjectReview} = require('src/server/graphql/schemas')
+
+    return {
+      user: {type: new GraphQLNonNull(UserProfile), description: 'The user'},
+      userProjectReviews: {type: new GraphQLList(UserProjectReview), description: 'The user\'s project reviews'},
+      userProjectStats: {type: UserProjectStats, description: 'The user\'s project stats'},
+    }
+  }
+})

--- a/server/graphql/schemas/ProjectWithReviewResponses.js
+++ b/server/graphql/schemas/ProjectWithReviewResponses.js
@@ -2,7 +2,7 @@ import {GraphQLNonNull, GraphQLID, GraphQLString} from 'graphql'
 import {GraphQLURL, GraphQLDateTime} from 'graphql-custom-types'
 import {GraphQLObjectType, GraphQLList} from 'graphql/type'
 
-import {resolveProjectChapter, resolveProjectCycle} from 'src/server/graphql/resolvers'
+import {resolveChapter, resolveCycle} from 'src/server/graphql/resolvers'
 
 export default new GraphQLObjectType({
   name: 'ProjectWithReviewResponses',
@@ -16,8 +16,8 @@ export default new GraphQLObjectType({
       artifactURL: {type: GraphQLURL, description: 'The URL pointing to the output of this project'},
       createdAt: {type: new GraphQLNonNull(GraphQLDateTime), description: 'When this record was created'},
       updatedAt: {type: new GraphQLNonNull(GraphQLDateTime), description: 'When this record was last updated'},
-      chapter: {type: Chapter, description: 'The chapter', resolve: resolveProjectChapter},
-      cycle: {type: Cycle, description: 'The cycle', resolve: resolveProjectCycle},
+      chapter: {type: Chapter, description: 'The chapter', resolve: resolveChapter},
+      cycle: {type: Cycle, description: 'The cycle', resolve: resolveCycle},
       projectReviewResponses: {
         type: new GraphQLList(ProjectReviewResponse),
         description: 'The responses to the named questions on the project review survey',

--- a/server/graphql/schemas/Survey.js
+++ b/server/graphql/schemas/Survey.js
@@ -2,7 +2,7 @@ import {GraphQLNonNull, GraphQLID} from 'graphql'
 import {GraphQLObjectType, GraphQLList} from 'graphql/type'
 import {GraphQLDateTime} from 'graphql-custom-types'
 
-import {resolveSurveyProject} from 'src/server/graphql/resolvers'
+import {resolveProject} from 'src/server/graphql/resolvers'
 
 export default new GraphQLObjectType({
   name: 'Survey',
@@ -15,7 +15,7 @@ export default new GraphQLObjectType({
       createdAt: {type: new GraphQLNonNull(GraphQLDateTime), description: 'When this record was created'},
       updatedAt: {type: new GraphQLNonNull(GraphQLDateTime), description: 'When this record was last updated'},
       questions: {type: new GraphQLNonNull(new GraphQLList(SurveyQuestion)), description: 'The questions for the survey'},
-      project: {type: Project, description: 'The project this survey relates to', resolve: resolveSurveyProject},
+      project: {type: Project, description: 'The project this survey relates to', resolve: resolveProject},
     }
   },
 })

--- a/server/graphql/schemas/UserProfile.js
+++ b/server/graphql/schemas/UserProfile.js
@@ -1,0 +1,34 @@
+
+import {GraphQLID, GraphQLString, GraphQLBoolean} from 'graphql'
+import {GraphQLObjectType, GraphQLList} from 'graphql/type'
+import {GraphQLDateTime, GraphQLEmail} from 'graphql-custom-types'
+
+import {resolveChapter, resolveUserStats} from 'src/server/graphql/resolvers'
+import {GraphQLPhoneNumber} from 'src/server/graphql/util'
+
+export default new GraphQLObjectType({
+  name: 'UserProfile',
+  description: 'A complete user profile',
+  fields: () => {
+    const {Chapter, UserStats} = require('src/server/graphql/schemas')
+
+    return {
+      id: {type: GraphQLID, description: 'The user\'s UUID'},
+      chapterId: {type: GraphQLID, description: 'The user\'s chapter UUID'},
+      chapter: {type: Chapter, description: 'The user\'s chapter', resolve: resolveChapter},
+      active: {type: GraphQLBoolean, description: 'True if the user is active'},
+      name: {type: GraphQLString, description: 'The user\'s name'},
+      handle: {type: GraphQLString, description: 'The user\'s handle'},
+      profileUrl: {type: GraphQLString, description: 'The user\'s profile URL'},
+      avatarUrl: {type: GraphQLString, description: 'The user\'s avatar image URL'},
+      email: {type: GraphQLEmail, description: 'The user\'s email'},
+      phone: {type: GraphQLPhoneNumber, description: 'The user\'s phone number'},
+      timezone: {type: GraphQLString, description: 'The user\'s timezone'},
+      roles: {type: new GraphQLList(GraphQLString), description: 'The user\'s roles'},
+      inviteCode: {type: GraphQLString, description: 'The invite code the user used to sign up'},
+      stats: {type: UserStats, resolve: resolveUserStats, description: 'The user\'s stats'},
+      createdAt: {type: GraphQLDateTime, description: 'When the user was created'},
+      updatedAt: {type: GraphQLDateTime, description: 'When the user was last updated'},
+    }
+  }
+})

--- a/server/graphql/schemas/UserProjectReview.js
+++ b/server/graphql/schemas/UserProjectReview.js
@@ -1,0 +1,23 @@
+import {GraphQLFloat, GraphQLString} from 'graphql'
+import {GraphQLObjectType} from 'graphql/type'
+import {GraphQLDateTime} from 'graphql-custom-types'
+
+export default new GraphQLObjectType({
+  name: 'UserProjectReview',
+  description: 'A user project review',
+  fields: () => {
+    const {UserProfile} = require('src/server/graphql/schemas')
+
+    return {
+      submittedBy: {type: UserProfile, description: 'The review submitter'},
+      contribution: {type: GraphQLFloat, description: 'The relative contribution rating'},
+      technical: {type: GraphQLFloat, description: 'The technical skill rating'},
+      culture: {type: GraphQLFloat, description: 'The culture contribution rating'},
+      teamPlay: {type: GraphQLFloat, description: 'The team play rating'},
+      focus: {type: GraphQLFloat, description: 'The results focus rating'},
+      leadership: {type: GraphQLFloat, description: 'The flexible leadership rating'},
+      general: {type: GraphQLString, description: 'General text feedback'},
+      createdAt: {type: GraphQLDateTime, description: 'The datetime of the review creation'},
+    }
+  },
+})

--- a/server/graphql/schemas/UserProjectStats.js
+++ b/server/graphql/schemas/UserProjectStats.js
@@ -1,0 +1,24 @@
+import {GraphQLFloat, GraphQLInt} from 'graphql'
+import {GraphQLObjectType} from 'graphql/type'
+
+export default new GraphQLObjectType({
+  name: 'UserProjectStats',
+  description: 'A user\'s stats for a project',
+  fields: () => {
+    const {UserStatContribution} = require('src/server/graphql/schemas')
+
+    return {
+      rating: {type: GraphQLInt, description: 'Rating'},
+      xp: {type: GraphQLFloat, description: 'Experience points'},
+      hours: {type: GraphQLFloat, description: 'Hours spent contributing to the project'},
+      culture: {type: GraphQLFloat, description: 'Culture contribution'},
+      technical: {type: GraphQLFloat, description: 'Technical support'},
+      teamPlay: {type: GraphQLFloat, description: 'Team play'},
+      receptiveness: {type: GraphQLFloat, description: 'Receptiveness score'},
+      focus: {type: GraphQLFloat, description: 'Results focus score'},
+      leadership: {type: GraphQLFloat, description: 'Flexible leadership score'},
+      friction: {type: GraphQLFloat, description: 'Friction reduction score'},
+      contribution: {type: UserStatContribution, description: 'Contribution stats'},
+    }
+  }
+})

--- a/server/graphql/schemas/UserProjectSummary.js
+++ b/server/graphql/schemas/UserProjectSummary.js
@@ -1,0 +1,16 @@
+import {GraphQLNonNull} from 'graphql'
+import {GraphQLObjectType, GraphQLList} from 'graphql/type'
+
+export default new GraphQLObjectType({
+  name: 'UserProjectSummary',
+  description: 'User project summary',
+  fields: () => {
+    const {Project, UserProjectStats, UserProjectReview} = require('src/server/graphql/schemas')
+
+    return {
+      project: {type: new GraphQLNonNull(Project), description: 'The project'},
+      userProjectReviews: {type: new GraphQLList(UserProjectReview), description: 'The user\'s project reviews'},
+      userProjectStats: {type: UserProjectStats, description: 'The user\'s project stats'},
+    }
+  }
+})

--- a/server/graphql/schemas/UserStatContribution.js
+++ b/server/graphql/schemas/UserStatContribution.js
@@ -1,0 +1,17 @@
+import {GraphQLFloat} from 'graphql'
+import {GraphQLObjectType} from 'graphql/type'
+
+export default new GraphQLObjectType({
+  name: 'UserStatContribution',
+  description: 'Relative contribution stats',
+  fields: () => {
+    return {
+      other: {type: GraphQLFloat, description: 'Teammate-rated relative contribution'},
+      self: {type: GraphQLFloat, description: 'Self-rated relative contribution'},
+      perHour: {type: GraphQLFloat, description: 'Relative contribution per hour'},
+      expected: {type: GraphQLFloat, description: 'Expected contribution'},
+      estimated: {type: GraphQLFloat, description: 'Estimated contribution'},
+      delta: {type: GraphQLFloat, description: 'Expected contribution delta'},
+    }
+  }
+})

--- a/server/graphql/schemas/UserStats.js
+++ b/server/graphql/schemas/UserStats.js
@@ -1,0 +1,13 @@
+import {GraphQLInt, GraphQLFloat} from 'graphql'
+import {GraphQLObjectType} from 'graphql/type'
+
+export default new GraphQLObjectType({
+  name: 'UserStats',
+  description: 'A user\'s overall stats',
+  fields: () => {
+    return {
+      rating: {type: GraphQLInt, description: 'User rating'},
+      xp: {type: GraphQLFloat, description: 'Experience points'},
+    }
+  }
+})

--- a/server/graphql/schemas/UserSummary.js
+++ b/server/graphql/schemas/UserSummary.js
@@ -1,0 +1,17 @@
+import {GraphQLNonNull} from 'graphql'
+import {GraphQLObjectType, GraphQLList} from 'graphql/type'
+
+import {resolveUserProjectSummaries} from 'src/server/graphql/resolvers'
+
+export default new GraphQLObjectType({
+  name: 'UserSummary',
+  description: 'User summary',
+  fields: () => {
+    const {UserProfile, UserProjectSummary} = require('src/server/graphql/schemas')
+
+    return {
+      user: {type: new GraphQLNonNull(UserProfile), description: 'The user'},
+      userProjectSummaries: {type: new GraphQLList(UserProjectSummary), resolve: resolveUserProjectSummaries, description: 'The user\'s project summaries'},
+    }
+  }
+})

--- a/server/graphql/util/GraphQLPhoneNumber.js
+++ b/server/graphql/util/GraphQLPhoneNumber.js
@@ -1,0 +1,27 @@
+import {GraphQLScalarType} from 'graphql'
+import {GraphQLError} from 'graphql/error'
+import {Kind} from 'graphql/language'
+
+import {phoneNumberAsE164} from 'src/common/util/format'
+
+export default new GraphQLScalarType({
+  name: 'PhoneNumber',
+  serialize: parsePhoneNumber,
+  parseValue: parsePhoneNumber,
+  parseLiteral: ast => {
+    switch (ast.kind) {
+      case Kind.STRING:
+        return parsePhoneNumber(ast.value)
+      default:
+        throw new GraphQLError(`PhoneNumber must be a string, but it is a: ${ast.kind}`, [ast])
+    }
+  },
+})
+
+function parsePhoneNumber(str) {
+  try {
+    return phoneNumberAsE164(str)
+  } catch (err) {
+    throw new GraphQLError(err.message)
+  }
+}

--- a/server/graphql/util/index.js
+++ b/server/graphql/util/index.js
@@ -2,6 +2,8 @@ import {GraphQLError} from 'graphql/error'
 
 import {parseQueryError} from 'src/server/db/errors'
 
+export {default as GraphQLPhoneNumber} from './GraphQLPhoneNumber'
+
 export function handleError(unparsedError, defaultMsg) {
   const err = parseQueryError(unparsedError)
   if (err.name === 'BadInputError' || err.name === 'LGCustomQueryError') {

--- a/server/util/index.js
+++ b/server/util/index.js
@@ -60,9 +60,22 @@ export function pickRandom(arr) {
   return arr[Math.floor(Math.random() * arr.length)]
 }
 
-export function mapById(arr) {
-  return arr.reduce((result, el) => {
-    result.set(el.id, el)
+export function mapById(arr, idKey = 'id') {
+  return arr.reduce((result, item) => {
+    result.set(item[idKey], item)
+    return result
+  }, new Map())
+}
+
+export function groupById(arr, idKey = 'id') {
+  return arr.reduce((result, item) => {
+    const groupKey = item[idKey]
+    let group = result.get(groupKey)
+    if (!group) {
+      group = []
+    }
+    group.push(item)
+    result.set(groupKey, group)
     return result
   }, new Map())
 }

--- a/server/util/stats.js
+++ b/server/util/stats.js
@@ -144,3 +144,12 @@ function _validatePlayer(player) {
     throw new Error('Invalid player kFactor')
   }
 }
+
+export function findValueForReponseQuestionStat(responseArr, statDescriptor) {
+  if (!Array.isArray(responseArr) || !statDescriptor) {
+    return
+  }
+  return (responseArr.find(response => (
+    ((response.question || {}).stat || {}).descriptor === statDescriptor
+  )) || {}).value
+}

--- a/server/workers/__tests__/surveyResponseSubmitted.test.js
+++ b/server/workers/__tests__/surveyResponseSubmitted.test.js
@@ -131,7 +131,7 @@ describe(testContext(__filename), function () {
 
       describe('when the survey has been completed', function () {
         beforeEach(function () {
-          const overwriteObjs = [this.questionA, this.questionB].map((question, i) => ({
+          const overwriteObjs = [this.questionCompleteness, this.questionQuality].map((question, i) => ({
             questionId: question.id,
             surveyId: this.survey.id,
             subjectId: this.project.id,

--- a/test/factories/project.js
+++ b/test/factories/project.js
@@ -26,9 +26,16 @@ export default function define(factory) {
       })
     },
     goal: factory.sequence(n => {
+      const url = `http://example.com/repo/issue/${n}`
+      const title = `Goal #${n}`
       return {
-        url: `http://example.com/repo/issue/${n}`,
-        title: `Goal #${n}`,
+        url,
+        title,
+        githubIssue: {
+          url,
+          title,
+          number: n,
+        },
       }
     }),
     artifactURL: factory.sequence(n => `http://artifact.example.com/${n}`),

--- a/test/factories/user.js
+++ b/test/factories/user.js
@@ -10,6 +10,7 @@ export default function define(factory) {
     emails: cb => cb(null, [faker.internet.exampleEmail(), faker.internet.exampleEmail()]),
     handle: cb => cb(null, `${faker.random.word()}${faker.random.number({max: 100})}`.toLowerCase()),
     avatarUrl: cb => cb(null, faker.image.imageUrl()),
+    profileUrl: cb => cb(null, 'http://me.com'),
     name: cb => cb(null, faker.name.findName()),
     phone: cb => cb(null, faker.phone.phoneNumber('(###) ###-####')),
     dateOfBirth: cb => cb(null, faker.date.past(21).toISOString().slice(0, 10)),

--- a/test/helpers/expectations.js
+++ b/test/helpers/expectations.js
@@ -1,5 +1,6 @@
 /* global expect */
 export function expectArraysToContainTheSameElements(a, b) {
+  expect(a.length).to.equal(b.length)
   expect(a.sort()).to.deep.equal(b.sort())
 }
 

--- a/test/helpers/graphql.js
+++ b/test/helpers/graphql.js
@@ -33,4 +33,3 @@ export function runGraphQLMutation(graphqlQueryString, fields, args = undefined,
 
   return runGraphQL(schema, graphqlQueryString, rootQuery, args)
 }
-


### PR DESCRIPTION
Related to #475.

## Overview
This one seems a bit hefty, but it should be fairly clean. Mostly GraphQL schema additions and some resolver functions.

Here's what's going on:

### GraphQL Query Field Updates

`findProjects(:identifiers)` **[New]**
- accepts an (optional) array of project identifiers and returns a list of projects

`getProject(:identifier)` **[New]**
- requires a project identifier and returns the matched project or an error if none found

`getProjectSummary(:identifier)` **[New]**
- requires a project identifier and returns the matched project summary or an error if none found
  
`findUsers(:identifiers)` **[New]**
- accepts an (optional) array of user identifiers and returns a unified/merged user object with props from both `idm` and `game` user accounts

`getUser(:identifier)` **[New]**
- requires a project identifier and returns the matched unified user or an error if none found

`getUserSummary(:identifier)` **[New]**
- requires a project identifier and returns the matched unified user or an error if none found

### User Permission Updates
- `listProjects` **[New]**
- `viewProject` **[New]**
- `viewProjectSummary` **[New]**
- `listUsers` **[New]**
- `viewUser` **[New]**
- `viewUserSummary` **[New]**

### GraphQL Schema Updates
`Goal` **[Updated]**  
- fields added:
  - `number`
  - `level`

`Project` **[Updated]**  
- fields added:
  - `goal`
  - `stats`

`ProjectStats` **[New]**  
- fields:
  - `hours`
  - `quality`
  - `completeness`

`ProjectReview` **[New]**  
- fields:
  - `submittedBy`
  - `completeness`
  - `quality`
  - `createdAt`

`ProjectSummary` **[New]**  
- fields:
  - `project`
  - `projectReviews`
  - `projectUserSummaries`

`ProjectUserSummary` **[New]**  
- fields:
  - `user`
  - `userProjectReviews`
  - `userProjectStats`

`UserProfile` **[New]**  
- fields:
  - `id`
  - `chapterId`
  - `chapter`
  - `name`
  - `handle`
  - `profileUrl`
  - `avatarUrl`
  - `email`
  - `phone`
  - `timezone`
  - `roles`
  - `active`
  - `inviteCode`
  - `stats`
  - `createdAt`
  - `updatedAt`

`UserStats` **[New]**  
- fields:
  - `rating`
  - `xp`

`UserStatContribution` **[New]**  
- fields:
  - `other`
  - `self`
  - `perHour`
  - `expected`
  - `estimated`
  - `delta`

`UserSummary` **[New]**  
- fields:
  - `user`
  - `userProjectSummaries`

`UserProjectReview` **[New]**  
- fields:
  - `submittedBy`
  - `contribution`
  - `technical`
  - `culture`
  - `teamPlay`
  - `focus`
  - `leadership`
  - `general`
  - `createdAt`

`UserProjectSummary` **[New]**  
- fields:
  - `project`
  - `userProjectReviews`
  - `userProjectStats`

`UserProjectStats` **[New]**  
- fields:
  - `rating`
  - `xp`
  - `hours`
  - `culture`
  - `technical`
  - `teamPlay`
  - `receptiveness`
  - `focus`
  - `leadership`
  - `friction`
  - `contribution`

`GraphQLPhoneNumber` **[New]**  
_(Sorta. Copied from `idm`. :)_

### Misc. Changes
- fixes thinky model associations during init
- adds missing props to thinky models
- adds small server util fns
- adds test helpers

This concludes the vast majority of the backend changes to support the new admin UI. Future PRs in this series will almost exclusively contain client-side updates.

## Data Model / DB Schema Changes

No _real_ model changes as it relates to what gets stored in the DB, but the GraphQL model has changed (additions only). No migration needed.

## Environment / Configuration Changes

Please run `npm i`!


