### PR TITLE
Retro survey `null` response value stopgap

### DIFF
--- a/common/util/survey.js
+++ b/common/util/survey.js
@@ -189,14 +189,14 @@ export function questionResponsesForFormFields(formFields, defaults) {
         case FORM_INPUT_TYPES.NUMERIC:
           response.values.push({
             subjectId,
-            value: field.value,
+            value: field.value === null ? '' : field.value,
           })
           break
 
         case FORM_INPUT_TYPES.SLIDER_GROUP:
           (field.value || []).forEach(fieldValue => response.values.push({
             subjectId: fieldValue.key,
-            value: fieldValue.value,
+            value: fieldValue.value === null ? '' : fieldValue.value,
           }))
           break
 


### PR DESCRIPTION
Fixes #656.

## Overview

If a user misses a response for a field in a page of the retro survey, the client will send `null` for the response value, which fails type validation for the input type of the graphql query made. As a result, the response error message is an unhelpful one about invalid types rather than an indication that a required response value is missing.

We've got other issues that address client-side validation and better server-side error handling, but in the meantime, this simple change checks field values for `null` and replaces any with an empty string before submitting them.

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.