### PR TITLE
Update project stats in stats script

### DIFF
--- a/server/actions/updateProjectStats.js
+++ b/server/actions/updateProjectStats.js
@@ -35,8 +35,8 @@ function getProjectStats(projectId) {
     .fold(r.object(), (acc, next) => acc.merge(next))
     // compute averages
     .do(stats => {
-      const avg = name => stats(name).avg().default(null)
-      const sum = name => stats(name).sum().default(null)
+      const avg = name => stats(name).map(s => s.coerceTo('number')).avg().default(null)
+      const sum = name => stats(name).map(s => s.coerceTo('number')).sum().default(null)
       return {
         completeness: avg('projectCompleteness'),
         quality: avg('projectQuality'),

--- a/server/services/dataService/models/player.js
+++ b/server/services/dataService/models/player.js
@@ -1,6 +1,6 @@
 
 export default function playerModel(thinky) {
-  const {r, type: {string, date}} = thinky
+  const {r, type: {string, date, object}} = thinky
 
   return {
     name: 'Player',
@@ -13,6 +13,10 @@ export default function playerModel(thinky) {
       chapterId: string()
         .uuid(4)
         .allowNull(false),
+
+      stats: object()
+        .allowNull(false)
+        .allowExtra(true),
 
       createdAt: date()
         .allowNull(false)


### PR DESCRIPTION
Fixes #652.
Fixes #672.

## Overview

- update projects stats along with player stats in `runStats` script
- coerce project survey responses to numbers when aggregating
- add `stats` field to thinky `Player` model

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.