### PR TITLE
Fix `cycleResponses` report timeouts

### DIFF
--- a/server/actions/getPlayerInfo.js
+++ b/server/actions/getPlayerInfo.js
@@ -3,7 +3,7 @@ import {graphQLFetcher} from 'src/server/util/graphql'
 
 export default function getPlayerInfo(playerIds) {
   return graphQLFetcher(config.server.idm.baseURL)({
-    query: 'query ($playerIds: [ID]!) { getUsersByIds(ids: $playerIds) { id active handle name roles } }',
+    query: 'query ($playerIds: [ID]!) { getUsersByIds(ids: $playerIds) { id active handle email name roles } }',
     variables: {playerIds},
   }).then(result => result.data.getUsersByIds)
 }

--- a/server/actions/getUsersByHandles.js
+++ b/server/actions/getUsersByHandles.js
@@ -3,7 +3,7 @@ import {graphQLFetcher} from 'src/server/util/graphql'
 
 export default function getUsersByHandles(userHandles) {
   return graphQLFetcher(config.server.idm.baseURL)({
-    query: 'query ($handles: [String]!) { getUsersByHandles(handles: $handles) { id handle name } }',
+    query: 'query ($handles: [String]!) { getUsersByHandles(handles: $handles) { id handle name email roles } }',
     variables: {handles: userHandles},
   }).then(result => result.data.getUsersByHandles)
 }


### PR DESCRIPTION
Fixes #659.

## Overview

The previous implementation of the `cycleResponses` report included a rethinkdb query that unnecessarily put too much load on the db server. This change not only makes the report orders of magnitude more performant, it hopefully makes the code more easily understandable.

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.

## Notes

This only addresses the `cycleResponses` report, but we'll almost certainly want to make similar changes to the implementation of other reports. Especially considering that this service isn't well suited for reporting to begin with and it's in our best interest to minimize the load these requests put on the service.
