### PR TITLE
Accept survey responses in COMPLETE cycle state

### DIFF
--- a/common/models/cycle.js
+++ b/common/models/cycle.js
@@ -9,3 +9,8 @@ export const CYCLE_STATES = [
   REFLECTION,
   COMPLETE,
 ]
+
+export const CYCLE_REFLECTION_STATES = [
+  REFLECTION,
+  COMPLETE,
+]

--- a/server/actions/__tests__/assertCycleInState.test.js
+++ b/server/actions/__tests__/assertCycleInState.test.js
@@ -1,0 +1,25 @@
+/* eslint-env mocha */
+/* global expect testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions, max-nested-callbacks */
+import {GOAL_SELECTION, PRACTICE, REFLECTION} from 'src/common/models/cycle'
+import factory from 'src/test/factories'
+
+import assertCycleInState from '../assertCycleInState'
+
+describe(testContext(__filename), function () {
+  beforeEach(async function () {
+    this.cycle = await factory.create('cycle', {state: GOAL_SELECTION})
+  })
+
+  it('throws an error for an unmatched single state', function () {
+    return expect(
+      assertCycleInState(this.cycle.id, PRACTICE)
+    ).to.be.rejectedWith(/cycle is in the GOAL_SELECTION state/)
+  })
+
+  it('throws an error for an unmatched state array', function () {
+    return expect(
+      assertCycleInState(this.cycle, [PRACTICE, REFLECTION])
+    ).to.be.rejectedWith(/cycle is in the GOAL_SELECTION state/)
+  })
+})

--- a/server/actions/assertCycleInState.js
+++ b/server/actions/assertCycleInState.js
@@ -1,0 +1,14 @@
+import {GraphQLError} from 'graphql/error'
+
+import {getCycleById} from 'src/server/db/cycle'
+
+export default async function assertCycleInState(cycleIdentifier, state) {
+  const cycle = typeof cycleIdentifier === 'string' ? await getCycleById(cycleIdentifier) : cycleIdentifier
+  if (!cycle || !cycle.state) {
+    throw new GraphQLError(`Cycle not found for identifier ${cycleIdentifier}`)
+  }
+  const cycleStates = Array.isArray(state) ? state : [state]
+  if (!cycleStates.includes(cycle.state)) {
+    throw new GraphQLError(`This action is not allowed when the cycle is in the ${cycle.state} state`)
+  }
+}

--- a/server/actions/findRetroSurveysForPlayer.js
+++ b/server/actions/findRetroSurveysForPlayer.js
@@ -3,9 +3,7 @@ import Promise from 'bluebird'
 import {connect} from 'src/db'
 import {compileSurveyDataForPlayer} from 'src/server/actions/compileSurveyData'
 import {Player, Project} from 'src/server/services/dataService'
-import {REFLECTION, COMPLETE} from 'src/common/models/cycle'
-
-const ACTIVE_CYCLE_RETRO_STATES = [REFLECTION, COMPLETE]
+import {CYCLE_REFLECTION_STATES} from 'src/common/models/cycle'
 
 const r = connect()
 
@@ -38,7 +36,7 @@ function _filterOpenProjectsForPlayer(playerId) {
     const containsPlayer = project => project('playerIds').contains(playerId)
     const hasRetroSurvey = project => project('retrospectiveSurveyId')
     const isInOpenCycle = project =>
-      r.expr(ACTIVE_CYCLE_RETRO_STATES).contains(
+      r.expr(CYCLE_REFLECTION_STATES).contains(
         r.table('cycles').get(
           project('cycleId').default('')
         ).default({})('state')

--- a/server/util/index.js
+++ b/server/util/index.js
@@ -60,9 +60,9 @@ export function pickRandom(arr) {
   return arr[Math.floor(Math.random() * arr.length)]
 }
 
-export function mapById(arr) {
+export function mapById(arr, idKey = 'id') {
   return arr.reduce((result, el) => {
-    result.set(el.id, el)
+    result.set(el[idKey], el)
     return result
   }, new Map())
 }


### PR DESCRIPTION
Fixes #688.

## Overview

#686 made it so that a retro survey will load for a player who hasn't submitted it yet if the cycle has moved into COMPLETE state, but it won't _accept_ the responses in this state - still required the cycle to be in REFLECTION state. An oversight where it was assumed that there was only one point of cycle state validation w.r.t. retro surveys.

This now accepts responses if the cycles linked to the projects linked to the surveys linked to the responses is in either REFLECTION or COMPLETE state.

![slam](https://cloud.githubusercontent.com/assets/1890882/21365195/1b92c7dc-c6a9-11e6-8d95-8149536f3c90.gif)

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.