### PR TITLE
disable project review notifications to chapter channel

### DIFF
--- a/server/workers/__tests__/surveyResponseSubmitted.test.js
+++ b/server/workers/__tests__/surveyResponseSubmitted.test.js
@@ -141,17 +141,15 @@ describe(testContext(__filename), function () {
           return factory.createMany('response', overwriteObjs, overwriteObjs.length)
         })
 
-        it('sends a message to the project and chapter chatrooms', function () {
+        it('sends a message to the project chatroom', function () {
           const event = {
             respondentId: this.project.playerIds[0],
             surveyId: this.survey.id,
           }
           return processSurveyResponseSubmitted(event, this.chatClientStub).then(() => {
-            [this.project.name, this.chapter.channelName].forEach(channel => {
-              const msg = this.chatClientStub.sentMessages[channel][0]
-              expect(msg).to.match(/project review has just been completed/)
-              expect(msg).to.match(/reviewed by 1 player./)
-            })
+            const msg = this.chatClientStub.sentMessages[this.project.name][0]
+            expect(msg).to.match(/project review has just been completed/)
+            expect(msg).to.match(/reviewed by 1 player./)
           })
         })
 
@@ -166,17 +164,14 @@ describe(testContext(__filename), function () {
           expect(project).to.have.property('stats')
         })
 
-        it('sends a message to the project and chapter chatrooms ONLY once each', async function () {
+        it('sends a message to the project chatroom ONLY once each', async function () {
           const event = {
             respondentId: this.project.playerIds[0],
             surveyId: this.survey.id,
           }
           await processSurveyResponseSubmitted(event, this.chatClientStub)
           await processSurveyResponseSubmitted(event, this.chatClientStub)
-          const channels = [this.project.name, this.chapter.channelName]
-          channels.forEach(channel => {
-            expect(this.chatClientStub.sentMessages[channel]).to.have.length(1)
-          })
+          expect(this.chatClientStub.sentMessages[this.project.name]).to.have.length(1)
         })
       })
 

--- a/server/workers/surveyResponseSubmitted.js
+++ b/server/workers/surveyResponseSubmitted.js
@@ -1,6 +1,5 @@
 import ChatClient from 'src/server/clients/ChatClient'
 import {processJobs} from 'src/server/util/queue'
-import {getChapterById} from 'src/server/db/chapter'
 import {findProjectBySurveyId} from 'src/server/db/project'
 import {getSurveyById, recordSurveyCompletedBy, surveyWasCompletedBy} from 'src/server/db/survey'
 import sendPlayerStatsSummaries from 'src/server/actions/sendPlayerStatsSummaries'
@@ -29,8 +28,6 @@ export async function processSurveyResponseSubmitted(event, chatClient = new Cha
   } catch (err) {
     return
   }
-
-  const chapter = await getChapterById(project.chapterId)
 
   let surveyType
   if (event.surveyId === project.retrospectiveSurveyId) {
@@ -73,7 +70,7 @@ export async function processSurveyResponseSubmitted(event, chatClient = new Cha
         console.log(`New Project Review Survey [${event.surveyId}] completed by [${event.respondentId}]`)
         const survey = changes[0].new_val
         announce(
-          [project.name, chapter.channelName],
+          [project.name],
           buildProjectReviewAnnouncement(project, survey),
           chatClient
         )


### PR DESCRIPTION
## Overview

Disable project review notifications to chapter channel. I'm leaving in the project room notifications, as that still seems useful and wasn't explicitly addressed in the ticket.

## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

none