### PR TITLE
give new players 1000 elo by default

### DIFF
--- a/server/workers/newGameUser.js
+++ b/server/workers/newGameUser.js
@@ -19,10 +19,12 @@ async function processNewGameUser(user) {
   await notifyCRMSystemOfPlayerSignUp(user)
 }
 
+const DEFAULT_PLAYER_STATS = {stats: {elo: {rating: 1000}}}
+
 const upsertToDatabase = {
   // we use .replace() instead of .insert() in case we get duplicates in the queue
   moderator: gameUser => replaceModerator(gameUser, {returnChanges: 'always'}),
-  player: gameUser => replacePlayer(gameUser, {returnChanges: 'always'}),
+  player: gameUser => replacePlayer({...gameUser, ...DEFAULT_PLAYER_STATS}, {returnChanges: 'always'}),
 }
 
 async function addUserToDatabase(user) {


### PR DESCRIPTION
Fixes [44](https://app.clubhouse.io/learnersguild/story/44/players-with-no-elo-should-be-treated-as-if-they-have-1000-elo)

## Overview

Give new players 1000 ELO by default.

## Data Model / DB Schema Changes
none
## Environment / Configuration Changes

none
