### PR TITLE
removing cycleLaunched worker retries and rollback

### DIFF
--- a/server/configureChangeFeeds/cycleStateChanged.js
+++ b/server/configureChangeFeeds/cycleStateChanged.js
@@ -36,11 +36,14 @@ function _getFeedProcessor(cycleStateChangedQueues) {
       const stateChangeIsInOrder = previousStateIndex === newStateIndex - 1
 
       if (stateChangeIsInOrder) {
-        const timeoutOpts = PRACTICE === cycle.state ? {timeout: 60 * 60000} : {}
-        const jobOpts = {
-          attempts: 3,
-          backoff: {type: 'fixed', delay: 10000},
-          ...timeoutOpts
+        let jobOpts
+        if (cycle.state === PRACTICE) {
+          jobOpts = {timeout: 60 * 60000}
+        } else {
+          jobOpts = {
+            attempts: 3,
+            backoff: {type: 'fixed', delay: 10000},
+          }
         }
         queue.add(cycle, jobOpts)
       } else {

--- a/server/workers/cycleLaunched/worker.js
+++ b/server/workers/cycleLaunched/worker.js
@@ -5,8 +5,6 @@ import sendCycleLaunchAnnouncement from 'src/server/actions/sendCycleLaunchAnnou
 import getPlayerInfo from 'src/server/actions/getPlayerInfo'
 import {findModeratorsForChapter} from 'src/server/db/moderator'
 import {findProjects} from 'src/server/db/project'
-import {update as updateCycle} from 'src/server/db/cycle'
-import {GOAL_SELECTION} from 'src/common/models/cycle'
 import {processJobs} from 'src/server/util/queue'
 import {getSocket} from 'src/server/util/socket'
 import ChatClient from 'src/server/clients/ChatClient'
@@ -31,17 +29,6 @@ export async function processCycleLaunch(cycle, options = {}) {
 }
 
 async function _handleCycleLaunchError(cycle, err) {
-  try {
-    // reset cycle state to GOAL_SELECTION
-    console.log(`Resetting state for cycle ${cycle.id} to GOAL_SELECTION`)
-    await updateCycle({id: cycle.id, state: GOAL_SELECTION})
-  } catch (err) {
-    console.error('Cycle state reset error:', err)
-  }
-
-  // delete any projects that were created
-  await findProjects({chapterId: cycle.chapterId, cycleId: cycle.id}).delete()
-
   console.log(`Notifying moderators of chapter ${cycle.chapterId} of cycle launch error`)
   await _notifyModerators(cycle, `❗️ **Cycle Launch Error:** ${err.message}`)
 }


### PR DESCRIPTION
## Overview

It's a lot easier to debug/fix issues if we don't remove the projects
that were created and most things that might cause this to fail once will
probably cause it to fail the second time as well.

Related to [ch238]. This can me merged independently from #701 though and will prevent the sorts of issues we saw last week. #701 just makes things more robust.


## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

none

