### PR TITLE
ProjectWithReviewResponses: include goal info

### DIFF
--- a/server/graphql/schemas/ProjectWithReviewResponses.js
+++ b/server/graphql/schemas/ProjectWithReviewResponses.js
@@ -2,17 +2,18 @@ import {GraphQLNonNull, GraphQLID, GraphQLString} from 'graphql'
 import {GraphQLURL, GraphQLDateTime} from 'graphql-custom-types'
 import {GraphQLObjectType, GraphQLList} from 'graphql/type'
 
-import {resolveChapter, resolveCycle} from 'src/server/graphql/resolvers'
+import {resolveChapter, resolveCycle, resolveProjectGoal} from 'src/server/graphql/resolvers'
 
 export default new GraphQLObjectType({
   name: 'ProjectWithReviewResponses',
   description: 'A project which includes any project review survey responses for the current user',
   fields: () => {
-    const {Chapter, Cycle, ProjectReviewResponse} = require('src/server/graphql/schemas')
+    const {Chapter, Cycle, Goal, ProjectReviewResponse} = require('src/server/graphql/schemas')
 
     return {
       id: {type: new GraphQLNonNull(GraphQLID), description: "The project's UUID"},
       name: {type: new GraphQLNonNull(GraphQLString), description: 'The project name'},
+      goal: {type: Goal, description: 'The project goal', resolve: resolveProjectGoal},
       artifactURL: {type: GraphQLURL, description: 'The URL pointing to the output of this project'},
       createdAt: {type: new GraphQLNonNull(GraphQLDateTime), description: 'When this record was created'},
       updatedAt: {type: new GraphQLNonNull(GraphQLDateTime), description: 'When this record was last updated'},


### PR DESCRIPTION
Partially addresses [ch204](https://app.clubhouse.io/learnersguild/story/204/project-list-r-should-list-the-goal).

## Overview

To minimizes time wasted by Support Engineering answering questions about which goals are associated with which projects.

Each project line in the output for `project list -r` will now show the goal number and title. So we need the game API to return the goal info, as well.

## Data Model / DB Schema Changes

`ProjectWithReviewResponses` now includes the goal info.

## Environment / Configuration Changes

N/A

## Notes

N/A