### PR TITLE
fix failing build

### DIFF
--- a/server/actions/__tests__/updatePlayerStatsForProject.test.js
+++ b/server/actions/__tests__/updatePlayerStatsForProject.test.js
@@ -18,6 +18,7 @@ describe(testContext(__filename), function () {
     useFixture.buildSurvey()
 
     beforeEach('Setup Survey Data', async function () {
+      useFixture.nockClean()
       await reloadSurveyAndQuestionData()
 
       this.setupSurveyData = async customResponses => {


### PR DESCRIPTION
Fixes [ch639](https://app.clubhouse.io/learnersguild/story/639/fix-failing-build).

## Overview

[The build has been failing](https://codeship.com/projects/158610/builds/6ca195e7-17d2-4978-8e20-06dbee8e06e6). The reason is because of interactions between different tests and the way they differently `nock` calls to the IDM service. The fix was to make sure we start with a clean slate before each of the `updatePlayerStatsForProject` tests.

## Data Model / DB Schema Changes

N/A

## Environment / Configuration Changes

N/A

## Notes

N/A