### PR TITLE
ignore mousewheel events for numeric survey inputs

### DIFF
--- a/common/components/SurveyFormInputNumeric/index.jsx
+++ b/common/components/SurveyFormInputNumeric/index.jsx
@@ -14,9 +14,11 @@ class SurveyFormInputNumeric extends React.Component {
     }
   }
 
-  handleWheel(e) {
+  handleWheel(event) {
     // see: https://app.clubhouse.io/learnersguild/story/193/disable-scrolling-to-change-value-in-hours-input-field
-    e.preventDefault()
+    if (event) {
+      event.preventDefault()
+    }
   }
 
   render() {


### PR DESCRIPTION
Fixes [ch193](https://app.clubhouse.io/learnersguild/story/193/disable-scrolling-to-change-value-in-hours-input-field).

## Overview

The default HTML5 behavior for `<input type="number">` is, when a `mousescroll` event happens, to increment / decrement the numeric value. However, this often causes input errors because a user was trying to scroll the _page_, but inadvertently scrolled the _numeric value_ instead. So, on these inputs, we'll ignore `mousescroll` events.

## Data Model / DB Schema Changes

N/A

## Environment / Configuration Changes

N/A

## Notes

N/A
