### PR TITLE
exclude moderator and coach roles from voting

### DIFF
--- a/common/util/userCan.js
+++ b/common/util/userCan.js
@@ -44,6 +44,7 @@ const CAPABILITY_ROLES = {
   runReports: ['moderator', 'sysadmin'],
   monitorJobQueues: ['sysadmin'],
   beIgnoredWhenComputingElo: ['coach'],
+  beExcludedFromVoting: ['moderator', 'coach'],
 }
 
 export const VALID_ROLES = Object.keys(CAPABILITY_ROLES).map(capability => {

--- a/server/actions/__tests__/findActiveVotingPlayersInChapter.test.js
+++ b/server/actions/__tests__/findActiveVotingPlayersInChapter.test.js
@@ -1,0 +1,28 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions, max-nested-callbacks */
+import {truncateDBTables, useFixture} from 'src/test/helpers'
+import factory from 'src/test/factories'
+
+import findActiveVotingPlayersInChapter from 'src/server/actions/findActiveVotingPlayersInChapter'
+
+describe(testContext(__filename), function () {
+  before(truncateDBTables)
+
+  beforeEach(function () {
+    useFixture.nockClean()
+  })
+
+  it('returns players for the given chapter who are active and can vote according to IDM', async function () {
+    const chapter = await factory.create('chapter')
+    const players = await factory.createMany('player', {chapterId: chapter.id}, 10)
+    const users = players.map(_ => ({id: _.id, active: true}))
+    users[0].active = users[1].active = false
+    users[2].roles = users[3].roles = ['coach']
+    useFixture.nockIDMGetUsersById(users)
+
+    const activePlayers = await findActiveVotingPlayersInChapter(chapter.id)
+
+    expect(activePlayers.length).to.equal(6)
+  })
+})

--- a/server/actions/createPoolsForCycle.js
+++ b/server/actions/createPoolsForCycle.js
@@ -3,7 +3,7 @@ import {savePools, addPlayerIdsToPool} from 'src/server/db/pool'
 import {flatten} from 'src/common/util'
 import {shuffle, range} from 'src/server/util'
 import {LEVELS, computePlayerLevel} from 'src/server/util/stats'
-import findActivePlayersInChapter from 'src/server/actions/findActivePlayersInChapter'
+import findActiveVotingPlayersInChapter from 'src/server/actions/findActiveVotingPlayersInChapter'
 
 const MAX_POOL_SIZE = 15
 const POOL_NAMES = [
@@ -21,7 +21,7 @@ const POOL_NAMES = [
 ]
 
 export default async function createPoolsForCycle(cycle) {
-  const players = await findActivePlayersInChapter(cycle.chapterId)
+  const players = await findActiveVotingPlayersInChapter(cycle.chapterId)
   const poolAssignments = _splitPlayersIntoPools(players)
   await _savePoolAssignments(cycle, poolAssignments)
 }

--- a/server/actions/findActiveVotingPlayersInChapter.js
+++ b/server/actions/findActiveVotingPlayersInChapter.js
@@ -1,0 +1,15 @@
+import {findPlayersForChapter} from 'src/server/db/player'
+import {mapById} from 'src/server/util'
+import {userCan} from 'src/common/util'
+import getPlayerInfo from 'src/server/actions/getPlayerInfo'
+
+export default async function findActiveVotingPlayersInChapter(chapterId) {
+  const players = await findPlayersForChapter(chapterId)
+  const playerIds = players.map(_ => _.id)
+  const idmUsers = await getPlayerInfo(playerIds)
+  const idmUserMap = mapById(idmUsers)
+  return players.filter(player => {
+    const idmUser = idmUserMap.get(player.id)
+    return idmUser.active && !userCan(idmUser, 'beExcludedFromVoting')
+  })
+}


### PR DESCRIPTION
Fixes [CH195](https://app.clubhouse.io/learnersguild/story/195/seps-and-other-staff-should-not-be-placed-in-pools-during-cycle-initialization)

## Overview

Filtering out moderators and coaches when forming voting pools.

## Data Model / DB Schema Changes

None

## Environment / Configuration Changes

None

## Notes

nope
