### PR TITLE
fix disappearing githubTeamId

### DIFF
--- a/server/db/chapter.js
+++ b/server/db/chapter.js
@@ -1,5 +1,5 @@
 import {connect} from 'src/db'
-import {insertIntoTable, replaceInTable} from 'src/server/db/util'
+import {insertIntoTable} from 'src/server/db/util'
 
 const r = connect()
 export const chaptersTable = r.table('chapters')
@@ -23,15 +23,7 @@ export function findChapters() {
 }
 
 export function saveChapter(chapter, options) {
-  if (chapter.id) {
-    return replace(chapter, options)
-  }
-
-  return insert(chapter, options)
-}
-
-function replace(chapter, options) {
-  return replaceInTable(chapter, chaptersTable, options)
+  return insert(chapter, {...options, conflict: 'update'})
 }
 
 function insert(chapter, options) {

--- a/server/graphql/mutations/__tests__/createOrUpdateChapter.test.js
+++ b/server/graphql/mutations/__tests__/createOrUpdateChapter.test.js
@@ -1,0 +1,96 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+import factory from 'src/test/factories'
+import {Chapter} from 'src/server/services/dataService'
+import {withDBCleanup, runGraphQLMutation} from 'src/test/helpers'
+
+import fields from '../index'
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+
+  describe('createOrUpdateChapter', function () {
+    beforeEach('create moderator', async function () {
+      this.moderatorUser = await factory.build('user', {roles: ['moderator', 'backoffice']})
+      this.moderator = await factory.create('moderator', {id: this.moderatorUser.id})
+    })
+
+    before(function () {
+      this.createOrUpdateChapter = function (inputChapter) {
+        return runGraphQLMutation(
+          `mutation($chapter: InputChapter!) { createOrUpdateChapter(chapter: $chapter) {
+            id
+            name
+            channelName
+            timezone
+            goalRepositoryURL
+            githubTeamId
+            cycleDuration
+            cycleEpoch
+            inviteCodes
+            createdAt
+            updatedAt
+          }}`,
+          fields,
+          {chapter: inputChapter},
+          {currentUser: this.moderatorUser},
+        )
+      }
+    })
+
+    it('creates a new chapter', async function () {
+      const chapterAttrs = await factory.build('chapter')
+      const {
+        name,
+        channelName,
+        timezone,
+        goalRepositoryURL,
+        cycleDuration,
+        cycleEpoch,
+        inviteCodes,
+      } = chapterAttrs
+      const result = await this.createOrUpdateChapter({
+        name,
+        channelName,
+        timezone,
+        goalRepositoryURL,
+        cycleDuration,
+        cycleEpoch,
+        inviteCodes,
+      })
+      const returnedChapter = result.data.createOrUpdateChapter
+      expect(returnedChapter).to.have.property('name').eq(name)
+      expect(returnedChapter).to.have.property('channelName').eq(channelName)
+      expect(returnedChapter).to.have.property('timezone').eq(timezone)
+      expect(returnedChapter).to.have.property('goalRepositoryURL').eq(goalRepositoryURL)
+      expect(returnedChapter).to.have.property('cycleDuration').eq(cycleDuration)
+    })
+
+    it('updates an existing chapter without changing unspecified attrs', async function () {
+      const chapter = await factory.create('chapter')
+      const {
+        id,
+        name,
+        channelName,
+        timezone,
+        goalRepositoryURL,
+        cycleDuration,
+        cycleEpoch,
+        inviteCodes,
+      } = chapter
+      await this.createOrUpdateChapter({
+        id,
+        name,
+        channelName,
+        timezone,
+        goalRepositoryURL,
+        cycleDuration,
+        cycleEpoch,
+        inviteCodes: [...inviteCodes, 'newCodes'],
+      })
+      const updatedChapter = await Chapter.get(chapter.id)
+      expect(chapter.githubTeamId).to.deep.eq(updatedChapter.githubTeamId)
+    })
+  })
+})

--- a/test/factories/chapter.js
+++ b/test/factories/chapter.js
@@ -12,7 +12,7 @@ export default function define(factory) {
     channelName: function (cb) { cb(null, faker.helpers.slugify(this.name).toLowerCase()) },
     timezone: 'America/Los_Angeles',
     goalRepositoryURL: cb => cb(null, 'https://github.com/GuildCraftsTesting/web-development-js-testing'),
-    githubTeamId: cb => cb(null, null),
+    githubTeamId: factory.sequence(n => n),
     cycleDuration: '1 week',
     cycleEpoch: cb => cb(null, now),
     inviteCodes: [],


### PR DESCRIPTION
Fixes [ch884](https://app.clubhouse.io/learnersguild/story/884/githubteamid-keeps-disappearing-in-db)

## Overview

Because we were using a replace to update the chapter attributes
that were not specified were being removed. Since `githubTeamId` is not
accepted in the API it was always being removed from the record when the
chapter got updated (usually because we were adding an invite code).

## Data Model / DB Schema Changes

nope

## Environment / Configuration Changes

nope

## Notes

nope
