### PR TITLE
single-player projects: default reported hours to 0 if there is no response for hours

### DIFF
--- a/server/actions/updatePlayerStatsForProject.js
+++ b/server/actions/updatePlayerStatsForProject.js
@@ -89,7 +89,7 @@ async function _updateSinglePlayerProjectStats(project) {
   const [playerId] = project.playerIds
   const expectedHours = project.expectedHours || 40
   const {retroResponses, statsQuestions} = await _getRetroQuestionsAndResponses(project)
-  const reportedHours = _playerResponsesForQuestionById(retroResponses, statsQuestions.hours.id, _ => parseInt(_, 10)).get(playerId)
+  const reportedHours = _playerResponsesForQuestionById(retroResponses, statsQuestions.hours.id, _ => parseInt(_, 10)).get(playerId) || 0
   const challenge = _playerResponsesForQuestionById(retroResponses, statsQuestions.challenge.id).get(playerId)
   const hours = Math.min(reportedHours, expectedHours)
 


### PR DESCRIPTION
Fixes [ch937](https://app.clubhouse.io/learnersguild/story/937/npm-run-stats-completely-broken).

## Overview

When we added the ability to support single-player projects, we introduced a bug where if the player did not answer the question about how many hours they worked, it would not default to 0, and would instead be `undefined`. Later, this value was passed to `Math.min`, which returned `NaN`, which is not able to be saved in the database because it's not part of the JSON spec.

This PR defaults the response for hours to 0 if it wasn't provided.

## Data Model / DB Schema Changes

N/A

## Environment / Configuration Changes

N/A

## Notes

N/A
