### PR TITLE
don't send errors to client if headers were set on response

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -84,14 +84,18 @@ export function start() {
         error: ${config.server.secure ? originalError.toString() : originalError.stack}`)
     }
 
-    res.status(serverError.statusCode)
-
-    if (req.accepts('json')) {
-      return res.json({errors: [serverError]})
+    if (res.headersSent) {
+      return
     }
 
-    const responseBody = `<h1>${serverError.statusCode} - ${serverError.type}</h1><p>${serverError.message}</p>`
-    res.send(responseBody)
+    res.status(serverError.statusCode)
+
+    if (req.accepts('html')) {
+      const responseBody = `<h1>${serverError.statusCode} - ${serverError.name || 'UNHANDLED ERROR'}</h1><p>${serverError.message}</p>`
+      return res.send(responseBody)
+    }
+
+    res.json({errors: [serverError]})
   })
 
   // socket cluster


### PR DESCRIPTION
Fixes [ch1128](https://app.clubhouse.io/learnersguild/story/1128/catch-all-error-handler-should-detect-if-headers-have-already-been-sent).

## Overview

Express.js chokes when you try to set the status code (e.g., `res.status(500)`) on a response that has already had headers set. Our error handler wasn't detecting that case (for example, when a streaming report may have set the `Content-Type` header to `text/csv` or `application/json`.

In addition to the aforementioned change, we now check to see if the request accepts HTML rather than checking to see if it accepts JSON, because most browsers will set the `Accept` header to `*/*`, whereas most API requests will go to the effort to set the `Accept` header to `application/json` (or whatever). This should help to prevent us from sending JSON-formatted error messages to a human.

## Data Model / DB Schema Changes

N/A

## Environment / Configuration Changes

N/A

## Notes

N/A