### PR TITLE
be more defensive when using `statsQuestions` data structure; fix project hours bug

### DIFF
--- a/server/actions/updatePlayerStatsForProject.js
+++ b/server/actions/updatePlayerStatsForProject.js
@@ -316,7 +316,7 @@ function _playerProjectHoursById(projectExpectedHours, retroResponses, statsQues
   // To simplify things, we just keep track of the `PROJECT_HOURS` stat, which will be
   // either derived (in the case that the survey asked for "time off") or raw (in the
   // case that the survey asked for "hours worked").
-  const surveyIncludesTimeOffHoursQuestion = Boolean(statsQuestions[PROJECT_TIME_OFF_HOURS].active)
+  const surveyIncludesTimeOffHoursQuestion = Boolean(statsQuestions[PROJECT_TIME_OFF_HOURS])
 
   if (surveyIncludesTimeOffHoursQuestion) {
     const teamPlayerProjectHours = _playerResponsesForQuestionById(retroResponses, statsQuestions.idFor(PROJECT_TIME_OFF_HOURS), _ => parseInt(_, 10))


### PR DESCRIPTION
Fixes [ch1265](https://app.clubhouse.io/learnersguild/story/1265/it-s-incorrect-to-use-the-active-flag-to-determine-whether-the-survey-asked-for-project-hours-or-project-time-off-hours).

## Overview

During the review of [this PR](https://github.com/LearnersGuild/game/pull/752), @bundacia found a bug related to the way we were (incorrectly) checking to see whether a question was `.active` or not, and then further pointed out that it's a bit weird that the `statsQuestions` data structure that we're using all over the place when computing stats returns `{}` rather than `undefined` for stats questions that don't exist in the survey. This PR addresses some of that ugliness, and fixes the `.active` problem, also.

## Data Model / DB Schema Changes

N/A

## Environment / Configuration Changes

N/A

## Notes

N/A
