### PR TITLE
Downgrading priority of team size 1 goals

### DIFF
--- a/server/services/projectFormationService/lib/ObjectiveAppraiser/index.js
+++ b/server/services/projectFormationService/lib/ObjectiveAppraiser/index.js
@@ -5,7 +5,7 @@ const MANDATORY_OBJECTIVES = [
 ]
 
 const WEIGHTED_OBJECTIVES = [
-  ['OnePlayerGoalVotesSatisfied', 150],
+  ['OnePlayerGoalVotesSatisfied', 10],
   ['TeamSizesMatchRecommendation', 100],
   ['PlayersGotTheirVote', 10],
   ['PlayersGetTeammatesTheyGaveGoodFeedback', 30],


### PR DESCRIPTION
## Overview

Too many people on team size 1 goals. Trying out lower the priority (dramatically) to see how things feel next week.


## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

none

## Notes

Will the algorithm take WAY longer to run now that it doesn't quickly assign team size 1 goals?
