### PR TITLE
project initialization: players are automatically added to the channel for their goal

### DIFF
--- a/server/actions/__tests__/initializeProject.test.js
+++ b/server/actions/__tests__/initializeProject.test.js
@@ -2,6 +2,7 @@
 /* global expect, testContext */
 /* eslint-disable prefer-arrow-callback, no-unused-expressions, max-nested-callbacks */
 import stubs from 'src/test/stubs'
+import {stub} from 'sinon'
 import factory from 'src/test/factories'
 import {withDBCleanup, mockIdmUsersById} from 'src/test/helpers'
 
@@ -15,23 +16,45 @@ describe(testContext(__filename), function () {
   })
 
   describe('initializeProject()', function () {
-    const {Player} = require('src/server/services/dataService')
-    const chatService = require('src/server/services/chatService')
-
-    const initializeProject = require('../initializeProject')
-
     beforeEach('setup data & mocks', async function () {
       this.project = await factory.create('project')
-      this.players = await Player.getAll(...this.project.playerIds)
       this.users = await mockIdmUsersById(this.project.playerIds)
     })
+    const chatService = require('src/server/services/chatService')
+    const initializeProject = require('../initializeProject')
 
-    it('creates the project channel and welcome messages', async function () {
-      const memberHandles = this.users.map(u => u.handle)
-      await initializeProject(this.project)
-      expect(chatService.createChannel).to.have.been.calledWith(this.project.name, [...memberHandles, 'echo'])
-      expect(chatService.sendChannelMessage).to.have.been.calledWithMatch(this.project.name, 'Welcome to the')
-      expect(chatService.sendChannelMessage).to.have.been.calledWithMatch(this.project.name, 'Your team is')
+    describe('when there is no goal channel', function () {
+      it('creates the project channel, goal channel, and welcome messages', async function () {
+        const memberHandles = this.users.map(u => u.handle)
+        await initializeProject(this.project)
+
+        expect(chatService.createChannel).to.have.been.calledWith(this.project.name, [...memberHandles, 'echo'])
+        expect(chatService.createChannel).to.have.been.calledWith(String(this.project.goal.githubIssue.number), [...memberHandles, 'echo'])
+        expect(chatService.sendChannelMessage).to.have.been.calledWithMatch(this.project.name, 'Welcome to the')
+        expect(chatService.sendChannelMessage).to.have.been.calledWithMatch(this.project.name, 'Your team is')
+      })
+    })
+
+    describe('when there is already a goal channel', function () {
+      beforeEach('alter the createChannel stub', async function () {
+        chatService.createChannel.restore()
+        stub(chatService, 'createChannel', () => {
+          throw new Error('error-duplicate-channel-name')
+        })
+      })
+
+      it('adds the new project\'s members to the goal channel', async function () {
+        await initializeProject(this.project)
+        const secondTeamProject = await factory.create('project')
+        secondTeamProject.goal.githubIssue.number = this.project.goal.githubIssue.number
+
+        const expectedChannelName = String(secondTeamProject.goal.githubIssue.number)
+        const secondTeamUsers = await mockIdmUsersById(secondTeamProject.playerIds)
+        const secondTeamHandles = secondTeamUsers.map(u => u.handle)
+
+        await initializeProject(secondTeamProject)
+        expect(chatService.joinChannel).to.have.been.calledWith(expectedChannelName, [...secondTeamHandles, 'echo'])
+      })
     })
   })
 })


### PR DESCRIPTION
Fixes # 1277

## Overview
During project Initialization, if there is no channel for that project's goal, the channel is created and players for that team are added to the new channel. Else, the players for the team are added to the existing goal channel.

## Data Model / DB Schema Changes
None.

## Environment / Configuration Changes
None.

## Notes
There's a possible edge case where one or more of the players has already joined the goal channel, but I didn't see any way of testing what happens in that case in the game repo - it sounds more like something that would come up on the echo-chat side of things ?

Edit: Looking at the echo-chat code, it seems to already be checking for an existing subscription before adding new users to a room.
