### PR TITLE
stats deltas: no change is calculated when there is a null for the previous week

### DIFF
--- a/common/util/__tests__/userProjectStatsCalculations.test.js
+++ b/common/util/__tests__/userProjectStatsCalculations.test.js
@@ -182,16 +182,16 @@ describe(testContext(__filename), () => {
       const projectsWithOverallStats = addPointInTimeOverallStats(projectSummaries)
       const projectsWithDeltas = addDeltaToStats(projectsWithOverallStats)
 
+      const currentStatsDiff = projectsWithDeltas[1].statsDifference
+
+      const latestProjectOverallStats = projectsWithDeltas[1].overallStats
+      const previousProjectOverallStats = projectsWithDeltas[2].overallStats
+
+      const inProgressProjectOverallStats = projectsWithDeltas[0].overallStats
+      const inProgressProjectStatsDiff = projectsWithDeltas[0].statsDifference
+
       expect(projectsWithDeltas).to.be.an('array')
       projectStatNames.forEach(stat => {
-        const currentStatsDiff = projectsWithDeltas[1].statsDifference
-
-        const latestProjectOverallStats = projectsWithDeltas[1].overallStats
-        const previousProjectOverallStats = projectsWithDeltas[2].overallStats
-
-        const inProgressProjectOverallStats = projectsWithDeltas[0].overallStats
-        const inProgressProjectStatsDiff = projectsWithDeltas[0].statsDifference
-
         expect(latestProjectOverallStats[stat] - previousProjectOverallStats[stat]).to.eql(currentStatsDiff[stat])
 
         expect(inProgressProjectOverallStats[stat]).to.be.null

--- a/common/util/userProjectStatsCalculations.js
+++ b/common/util/userProjectStatsCalculations.js
@@ -42,9 +42,22 @@ export function addDeltaToStats(summariesWithOverallStats) {
     const isPlayersFirstProject = i === summariesWithOverallStats.length - 1
 
     if (!isPlayersFirstProject) {
-      const previousOverallStats = summariesWithOverallStats[i + 1].overallStats
-      const getDiff = stat => ((overallStats[stat] === null) || (previousOverallStats[stat] === null))
-        ? null : overallStats[stat] - previousOverallStats[stat]
+      const getPreviousValueForStat = stat => {
+        for (let j = i + 1; j < summariesWithOverallStats.length; ++j) {
+          const previousOverallStats = summariesWithOverallStats[j].overallStats
+          if (previousOverallStats[stat] !== null) {
+            return previousOverallStats[stat]
+          }
+        }
+        return null
+      }
+      const getDiff = stat => {
+        const prevStatValue = getPreviousValueForStat(stat)
+        if (overallStats[stat] === null || prevStatValue === null) {
+          return null
+        }
+        return overallStats[stat] - prevStatValue
+      }
 
       projectStatNames.forEach(stat => {
         statsDifference[stat] = getDiff(stat)


### PR DESCRIPTION
Fixes # 1348

## Overview
Adds a check of the previousOverallStats for a given column to return a null change if that value is null.

## Data Model / DB Schema Changes
None.

## Environment / Configuration Changes
None.

## Notes
- Stats deltas are no longer showing as the total value for a stat when the previous week's value is null. 
- There is a separate issue with the way stats calculated over a 6 week period are displayed, because those stats do change even when there is no value for that week's project, but on those weeks the new total value isn't displayed or stored in the stats summaries.