### PR TITLE
fix bug with `channelName` in chapter form

### DIFF
--- a/common/actions/chapter.js
+++ b/common/actions/chapter.js
@@ -42,16 +42,6 @@ export function getChapter(id) {
 }
 
 export function saveChapter(chapter) {
-  const {cycleEpochDate, cycleEpochTime} = chapter
-  const cycleEpoch = new Date(cycleEpochDate)
-  cycleEpoch.setUTCHours(cycleEpochTime.getUTCHours())
-  cycleEpoch.setUTCMinutes(cycleEpochTime.getUTCMinutes())
-  cycleEpoch.setUTCSeconds(0)
-  cycleEpoch.setUTCMilliseconds(0)
-  const chapterData = Object.assign({}, chapter, {cycleEpoch})
-  delete chapterData.cycleEpochDate
-  delete chapterData.cycleEpochTime
-
   return {
     types: [
       types.SAVE_CHAPTER_REQUEST,
@@ -60,7 +50,7 @@ export function saveChapter(chapter) {
     ],
     shouldCallAPI: () => true,
     callAPI: (dispatch, getState) => {
-      const mutation = queries.createOrUpdateChapter(chapterData)
+      const mutation = queries.createOrUpdateChapter(chapter)
       return getGraphQLFetcher(dispatch, getState().auth)(mutation)
         .then(graphQLResponse => graphQLResponse.data.createOrUpdateChapter)
         .then(chapter => normalize(chapter, schemas.chapter))

--- a/common/actions/queries/createOrUpdateChapter.js
+++ b/common/actions/queries/createOrUpdateChapter.js
@@ -8,8 +8,6 @@ export default function createOrUpdateChapter(chapter) {
           name
           channelName
           timezone
-          cycleDuration
-          cycleEpoch
           inviteCodes
         }
       }

--- a/common/actions/queries/getAllChapters.js
+++ b/common/actions/queries/getAllChapters.js
@@ -7,8 +7,6 @@ export default function findChapters() {
           id
           name
           channelName
-          cycleEpoch
-          cycleDuration
           goalRepositoryURL
           inviteCodes
           activeProjectCount

--- a/common/actions/queries/getAllPlayers.js
+++ b/common/actions/queries/getAllPlayers.js
@@ -10,8 +10,6 @@ export default function getAllPlayers() {
             name
             channelName
             timezone
-            cycleDuration
-            cycleEpoch
             inviteCodes
           }
           createdAt

--- a/common/actions/queries/getChapterById.js
+++ b/common/actions/queries/getChapterById.js
@@ -9,8 +9,6 @@ export default function getChapterById(id) {
           channelName
           timezone
           goalRepositoryURL
-          cycleDuration
-          cycleEpoch
           inviteCodes
         }
       }

--- a/common/actions/queries/getCycleVotingResults.js
+++ b/common/actions/queries/getCycleVotingResults.js
@@ -16,8 +16,6 @@ export default function getCycleVotingResults() {
               timezone
               goalRepositoryURL
               githubTeamId
-              cycleDuration
-              cycleEpoch
             }
           }
           pools {

--- a/common/actions/queries/reassignPlayersToChapter.js
+++ b/common/actions/queries/reassignPlayersToChapter.js
@@ -10,8 +10,6 @@ export default function reassignPlayersToChapter(playerIds, chapterId) {
             name
             channelName
             timezone
-            cycleDuration
-            cycleEpoch
             inviteCodes
           }
         }

--- a/common/components/ChapterForm/index.jsx
+++ b/common/components/ChapterForm/index.jsx
@@ -10,7 +10,7 @@ import InviteCodeForm from 'src/common/containers/InviteCodeForm'
 import ContentHeader from 'src/common/components/ContentHeader'
 import NotFound from 'src/common/components/NotFound'
 import {Flex} from 'src/common/components/Layout'
-import {FORM_TYPES, renderInput, renderDatePicker, renderTimePicker} from 'src/common/util/form'
+import {FORM_TYPES, renderInput} from 'src/common/util/form'
 import {slugify} from 'src/common/util'
 
 import styles from './index.scss'
@@ -25,10 +25,6 @@ class ChapterForm extends Component {
     this.handleSaveInviteCode = this.handleSaveInviteCode.bind(this)
     this.handleChangeName = this.handleChangeName.bind(this)
     this.handleChangeTimezone = this.handleChangeTimezone.bind(this)
-    this.handleChangeCycleEpochDate = this.handleChangeCycleEpochDate.bind(this)
-    this.handleChangeCycleEpochTime = this.handleChangeCycleEpochTime.bind(this)
-    this.handleParseCycleEpochDate = this.handleParseCycleEpochDate.bind(this)
-    this.handleParseCycleEpochTime = this.handleParseCycleEpochTime.bind(this)
     this.generateTimezoneDropdownValues()
   }
 
@@ -72,22 +68,6 @@ class ChapterForm extends Component {
 
   handleChangeTimezone(value) {
     this.props.change('timezone', value)
-  }
-
-  handleChangeCycleEpochDate(value) {
-    this.props.change('cycleEpochDate', value ? new Date(value) : new Date())
-  }
-
-  handleChangeCycleEpochTime(value) {
-    this.props.change('cycleEpochTime', value ? new Date(value) : new Date())
-  }
-
-  handleParseCycleEpochDate(value) {
-    return moment(value, 'D MMMM YYYY').toDate()
-  }
-
-  handleParseCycleEpochTime(value) {
-    return moment(value, 'h:mm a').toDate()
   }
 
   renderInviteCodeDialog() {
@@ -191,33 +171,6 @@ class ChapterForm extends Component {
             label="Goal Repository URL"
             hint="https://github.com/GuildCrafts/awesome-stuffs"
             component={renderInput}
-            required
-            />
-          <Field
-            name="cycleDuration"
-            type="tel"
-            icon="av_timer"
-            label="Cycle Duration"
-            hint="e.g., '1 week', '3 hours', etc."
-            component={renderInput}
-            required
-            />
-          <Field
-            name="cycleEpochDate"
-            icon="today"
-            label="Cycle Epoch Date"
-            component={renderDatePicker}
-            parse={this.handleParseCycleEpochDate}
-            onChange={this.handleChangeCycleEpochDate}
-            required
-            />
-          <Field
-            name="cycleEpochTime"
-            icon="watch_later"
-            label="Cycle Epoch Time"
-            component={renderTimePicker}
-            parse={this.handleParseCycleEpochTime}
-            onChange={this.handleChangeCycleEpochTime}
             required
             />
           {inviteCodeField}

--- a/common/components/__tests__/ChapterForm.test.js
+++ b/common/components/__tests__/ChapterForm.test.js
@@ -30,9 +30,6 @@ describe(testContext(__filename), function () {
       channelName: false,
       timezone: false,
       goalRepositoryURL: false,
-      cycleDuration: false,
-      cycleEpochDate: false,
-      cycleEpochTime: false,
     }
 
     this.mockFields = {
@@ -41,9 +38,6 @@ describe(testContext(__filename), function () {
       channelName: Object.assign({}, mockField, {name: 'channelName', onChange: changeField('channelName')}),
       timezone: Object.assign({}, mockField, {name: 'timezone', onChange: changeField('timezone')}),
       goalRepositoryURL: Object.assign({}, mockField, {name: 'timezone', onChange: changeField('goalRepositoryURL')}),
-      cycleDuration: Object.assign({}, mockField, {name: 'cycleDuration', onChange: changeField('cycleDuration')}),
-      cycleEpochDate: Object.assign({}, mockField, {name: 'cycleEpochDate', onChange: changeField('cycleEpochDate')}),
-      cycleEpochTime: Object.assign({}, mockField, {name: 'cycleEpochTime', onChange: changeField('cycleEpochTime')}),
     }
 
     this.mockAuth = {
@@ -84,7 +78,6 @@ describe(testContext(__filename), function () {
         id: true,
         name: true,
         channelName: true,
-        cycleDuration: true
       }
 
       const props = this.getProps()

--- a/common/containers/ChapterForm/index.jsx
+++ b/common/containers/ChapterForm/index.jsx
@@ -74,9 +74,7 @@ function mapStateToProps(state, props) {
   const inviteCodes = chapter && chapter.inviteCodes
   const sortedInviteCodes = (inviteCodes || []).sort()
   const timezone = (chapter || {}).timezone || moment.tz.guess()
-  const cycleEpochDate = chapter && chapter.cycleEpoch ? new Date(chapter.cycleEpoch) : undefined
-  const cycleEpochTime = chapter && chapter.cycleEpoch ? new Date(chapter.cycleEpoch) : undefined
-  const initialValues = Object.assign({}, {id, timezone, cycleEpochDate, cycleEpochTime}, chapter)
+  const initialValues = Object.assign({}, {id, timezone}, chapter)
 
   let formType = chapter ? FORM_TYPES.UPDATE : FORM_TYPES.CREATE
   if (id && !chapter && !isBusy) {
@@ -108,7 +106,7 @@ function mapDispatchToProps(dispatch, props) {
 const formOptions = {
   form: FORM_NAMES.CHAPTER,
   enableReinitialize: true,
-  asyncBlurFields: ['name', 'channelName', 'timezone', 'goalRepositoryURL', 'cycleDuration', 'cycleEpochDate', 'cycleEpochTime'],
+  asyncBlurFields: ['name', 'channelName', 'timezone', 'goalRepositoryURL'],
   asyncValidate: asyncValidate(chapterSchema, {abortEarly: false}),
 }
 

--- a/common/util/userCan.js
+++ b/common/util/userCan.js
@@ -17,7 +17,6 @@ const CAPABILITY_ROLES = {
   createCycle: ['moderator'],
   launchCycle: ['moderator'],
   updateCycle: ['moderator'],
-  editCycleDuration: ['moderator'],
   viewCycleVotingResults: GAME_PLAY,
 
   importProject: ['moderator'],

--- a/common/validations/chapter.js
+++ b/common/validations/chapter.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import yup from 'yup'
 import moment from 'moment-timezone'
-import juration from 'juration'
 
 export const chapterSchema = yup.object().shape({
   name: yup.string().required().min(3),
@@ -12,20 +11,4 @@ export const chapterSchema = yup.object().shape({
     value => moment.tz.names().indexOf(value) >= 0,
   ),
   goalRepositoryURL: yup.string().required().matches(/https?:\/\/github\.com\/.+\/.+/, '${path} must be a valid GitHub repository URL'),
-  cycleDuration: yup.string().required().test(
-    'is-valid-duration',
-    '${path} is not a valid duration',
-    function (value) {
-      let durationSecs
-      try {
-        durationSecs = juration.parse(value)
-      } catch (err) {
-        throw this.createError()
-      }
-      if (durationSecs < 300) {
-        throw this.createError({message: '${path} must be at least 5 minutes long'})
-      }
-      return true
-    }
-  ),
 })

--- a/db/migrations/20170306170923-removeCycleDurationAndEpoch.js
+++ b/db/migrations/20170306170923-removeCycleDurationAndEpoch.js
@@ -1,0 +1,17 @@
+exports.up = function (r) {
+  return Promise.all([
+    r.table('chapters').update({
+      cycleDuration: r.literal(),
+      cycleEpoch: r.literal(),
+    }),
+  ])
+}
+
+exports.down = function (r) {
+  return Promise.all([
+    r.table('chapters').update({
+      cycleDuration: '1 week',
+      cycleEpoch: '2016-07-11T03:00:00.000Z',
+    }),
+  ])
+}

--- a/server/graphql/mutations/__tests__/createOrUpdateChapter.test.js
+++ b/server/graphql/mutations/__tests__/createOrUpdateChapter.test.js
@@ -26,8 +26,6 @@ describe(testContext(__filename), function () {
             timezone
             goalRepositoryURL
             githubTeamId
-            cycleDuration
-            cycleEpoch
             inviteCodes
             createdAt
             updatedAt
@@ -46,8 +44,6 @@ describe(testContext(__filename), function () {
         channelName,
         timezone,
         goalRepositoryURL,
-        cycleDuration,
-        cycleEpoch,
         inviteCodes,
       } = chapterAttrs
       const result = await this.createOrUpdateChapter({
@@ -55,8 +51,6 @@ describe(testContext(__filename), function () {
         channelName,
         timezone,
         goalRepositoryURL,
-        cycleDuration,
-        cycleEpoch,
         inviteCodes,
       })
       const returnedChapter = result.data.createOrUpdateChapter
@@ -64,7 +58,6 @@ describe(testContext(__filename), function () {
       expect(returnedChapter).to.have.property('channelName').eq(channelName)
       expect(returnedChapter).to.have.property('timezone').eq(timezone)
       expect(returnedChapter).to.have.property('goalRepositoryURL').eq(goalRepositoryURL)
-      expect(returnedChapter).to.have.property('cycleDuration').eq(cycleDuration)
     })
 
     it('updates an existing chapter without changing unspecified attrs', async function () {
@@ -75,8 +68,6 @@ describe(testContext(__filename), function () {
         channelName,
         timezone,
         goalRepositoryURL,
-        cycleDuration,
-        cycleEpoch,
         inviteCodes,
       } = chapter
       await this.createOrUpdateChapter({
@@ -85,8 +76,6 @@ describe(testContext(__filename), function () {
         channelName,
         timezone,
         goalRepositoryURL,
-        cycleDuration,
-        cycleEpoch,
         inviteCodes: [...inviteCodes, 'newCodes'],
       })
       const updatedChapter = await Chapter.get(chapter.id)

--- a/server/graphql/schemas/Chapter.js
+++ b/server/graphql/schemas/Chapter.js
@@ -21,8 +21,6 @@ export default new GraphQLObjectType({
       timezone: {type: new GraphQLNonNull(GraphQLString), description: 'The user timezone'},
       goalRepositoryURL: {type: new GraphQLNonNull(GraphQLURL), description: 'The GitHub goal repository URL'},
       githubTeamId: {type: GraphQLInt, description: 'The GitHub team id'},
-      cycleDuration: {type: new GraphQLNonNull(GraphQLString), description: 'Duration of the cycle'},
-      cycleEpoch: {type: new GraphQLNonNull(GraphQLDateTime), description: 'The timestamp when the first cycle begins'},
       inviteCodes: {type: new GraphQLList(GraphQLString), description: 'The invite codes associated with this chapter'},
       latestCycle: {type: Cycle, resolve: resolveChapterLatestCycle, description: 'The latest cycle in the chapter'},
       activeProjectCount: {type: GraphQLInt, resolve: resolveChapterActiveProjectCount, description: 'The number of active projects associated with this chapter'},

--- a/server/graphql/schemas/InputChapter.js
+++ b/server/graphql/schemas/InputChapter.js
@@ -1,6 +1,6 @@
 import {GraphQLString, GraphQLNonNull, GraphQLID} from 'graphql'
 import {GraphQLInputObjectType, GraphQLList} from 'graphql/type'
-import {GraphQLDateTime, GraphQLURL} from 'graphql-custom-types'
+import {GraphQLURL} from 'graphql-custom-types'
 
 export default new GraphQLInputObjectType({
   name: 'InputChapter',
@@ -11,8 +11,6 @@ export default new GraphQLInputObjectType({
     channelName: {type: new GraphQLNonNull(GraphQLString), description: 'The chapter chat channel name'},
     timezone: {type: GraphQLString, description: 'The chapter timezone'},
     goalRepositoryURL: {type: new GraphQLNonNull(GraphQLURL), description: 'The GitHub goal repository URL'},
-    cycleDuration: {type: new GraphQLNonNull(GraphQLString), description: 'The cycle duration'},
-    cycleEpoch: {type: GraphQLDateTime, description: 'The start timestamp of the first cycle'},
     inviteCodes: {type: new GraphQLList(GraphQLString), description: 'The invite codes associated with this chapter'},
   })
 })

--- a/server/services/dataService/models/chapter.js
+++ b/server/services/dataService/models/chapter.js
@@ -26,12 +26,6 @@ export default function chapterModel(thinky) {
         .allowNull(true)
         .default(null),
 
-      cycleDuration: string()
-        .allowNull(false),
-
-      cycleEpoch: date()
-        .allowNull(false),
-
       inviteCodes: array()
         .allowNull(false),
 

--- a/test/factories/chapter.js
+++ b/test/factories/chapter.js
@@ -13,8 +13,6 @@ export default function define(factory) {
     timezone: 'America/Los_Angeles',
     goalRepositoryURL: cb => cb(null, 'https://github.com/GuildCraftsTesting/web-development-js-testing'),
     githubTeamId: factory.sequence(n => n),
-    cycleDuration: '1 week',
-    cycleEpoch: cb => cb(null, now),
     inviteCodes: [],
     createdAt: cb => cb(null, now),
     updatedAt: cb => cb(null, now),


### PR DESCRIPTION
Fixes [ch1323](https://app.clubhouse.io/learnersguild/story/1323/creating-new-chapters-may-be-broken).

## Overview

When we updated to redux-form version 6, we broke the functionality that automatically derived `channelName` from `name`.

While I was in there, I also removed `cycleDuration` and `cycleEpoch`, which have never been used and, as such, were just dead weight cluttering up the code and database for no good reason.

## Data Model / DB Schema Changes

There's a new migration to remove the unused `cycleDuration` and`cycleEpoch` attributes from the chapters table.

## Environment / Configuration Changes

N/A

## Notes

N/A