### PR TITLE
Fixing a few review stat bugs

### DIFF
--- a/server/actions/findClosedProjectsReviewedByUser.js
+++ b/server/actions/findClosedProjectsReviewedByUser.js
@@ -2,12 +2,13 @@ import {Response, Project} from 'src/server/services/dataService'
 import {groupById} from 'src/server/util'
 import {connect} from 'src/db'
 import {STAT_DESCRIPTORS} from 'src/common/models/stat'
+import {PROJECT_STATES} from 'src/common/models/project'
 
 const r = connect()
 
 const {PROJECT_COMPLETENESS, PROJECT_QUALITY} = STAT_DESCRIPTORS
 
-export default async function findProjectsReviewedByUser(userId, {since = r.minval, before = r.maxval} = {}) {
+export default async function findClosedProjectsReviewedByUser(userId, {since = r.minval, before = r.maxval} = {}) {
   const projectReviewResponses = Response
     .between(since, before, {index: 'createdAt', leftBound: 'open'})
     .getJoin({question: {stat: true}})
@@ -28,6 +29,6 @@ export default async function findProjectsReviewedByUser(userId, {since = r.minv
     return [...result, projectId]
   }, [])
 
-  return await Project.getAll(...projectIds)
+  return await Project.getAll(...projectIds).filter({state: PROJECT_STATES.CLOSED})
 }
 

--- a/server/util/__tests__/stats.test.js
+++ b/server/util/__tests__/stats.test.js
@@ -480,7 +480,7 @@ describe(testContext(__filename), function () {
     describe('calculateProjectReviewStatsForPlayer', function () {
       const player = {id: 'p1'}
       let i = 0
-      const buildProjectReviewInfo = ({playerResponses, projectStats, year = '2017'}) => {
+      const buildProjectReviewInfo = ({playerResponses, projectStats, closedAt = new Date('2017-01-01')}) => {
         i += 1
         return ({
           project: {
@@ -490,7 +490,7 @@ describe(testContext(__filename), function () {
               [PROJECT_QUALITY]: projectStats.q,
               [PROJECT_COMPLETENESS]: projectStats.c,
             },
-            closedAt: new Date(`${year}-01-${i}`)
+            closedAt,
           },
           projectReviews: buildReviews([
             {playerId: externalPlayerIds[0], rxp: 90, q: 90, c: 90},
@@ -559,18 +559,18 @@ describe(testContext(__filename), function () {
 
       it('uses only the most recent 20 reviews for accuracy', function () {
         const projectReviewInfoList = [
-          ...range(1, 20).map(() =>
-            buildProjectReviewInfo({
-              playerResponses: {q: 80, c: 80},
-              projectStats: {q: 90, c: 90},
-              year: '2017'
-            })
-          ),
-          ...range(1, 10).map(() =>
+          ...range(1, 10).map(i =>
             buildProjectReviewInfo({
               playerResponses: {q: 90, c: 90},
               projectStats: {q: 90, c: 90},
-              year: '1999'
+              closedAt: new Date(`1999-01-${i}`),
+            })
+          ),
+          ...range(1, 20).map(i =>
+            buildProjectReviewInfo({
+              playerResponses: {q: 80, c: 80},
+              projectStats: {q: 90, c: 90},
+              closedAt: new Date(`2017-01-${i}`),
             })
           ),
         ]

--- a/server/util/stats.js
+++ b/server/util/stats.js
@@ -1,8 +1,13 @@
 import elo from 'elo-rank'
 
-import {roundDecimal, range} from 'src/common/util'
+import {
+  avg,
+  toPercent,
+  roundDecimal,
+  range,
+  attrCompareFn,
+} from 'src/common/util'
 import {STAT_DESCRIPTORS} from 'src/common/models/stat'
-import {avg, toPercent} from './index'
 
 export const LIKERT_SCORE_NA = 0
 export const LIKERT_SCORE_MIN = 1
@@ -332,7 +337,11 @@ export function calculateProjectReviewStatsForPlayer(player, projectReviewInfoLi
   const statNames = [PROJECT_COMPLETENESS, PROJECT_QUALITY]
   const isExternal = reviewInfo => !reviewInfo.project.playerIds.includes(player.id)
   const externalReviewInfoList = projectReviewInfoList.filter(isExternal)
-  const recentExternalReviewInfoList = externalReviewInfoList.slice(0, RELEVANT_EXTERNAL_REVIEW_COUNT)
+  const compareClosedAt = attrCompareFn('closedAt')
+  const recentExternalReviewInfoList = externalReviewInfoList
+    .sort(({project: a}, {project: b}) => compareClosedAt(a, b))
+    .reverse()
+    .slice(0, RELEVANT_EXTERNAL_REVIEW_COUNT)
 
   const baseline = player.statsBaseline || {}
   const internalCountBaseline = baseline[INTERNAL_PROJECT_REVIEW_COUNT] || 0


### PR DESCRIPTION
## Overview

* When calculating review stats we need to make sure to only look at closed projects
* When selecting the 20 projects to use we need to sort by closedAt descending

## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

none