### PR TITLE
Fix display bug with XP (and ELO)

### DIFF
--- a/common/components/UserProjectSummary/index.jsx
+++ b/common/components/UserProjectSummary/index.jsx
@@ -20,12 +20,12 @@ export default class UserProjectSummary extends Component {
 
   renderUserProjectStats() {
     const userStats = this.props.userProjectStats || {}
+    const {overallStats = {}, statsDifference} = this.props
+
     const projectStats = {
       ...userStats,
-      [STAT_DESCRIPTORS.ELO]: null,
-      [STAT_DESCRIPTORS.EXPERIENCE_POINTS]: null
+      [STAT_DESCRIPTORS.ELO]: statsDifference[STAT_DESCRIPTORS.ELO],
     }
-    const {overallStats = {}, statsDifference} = this.props
     return !objectValuesAreAllNull(userStats) ? ([
       <Flex key="stats" fill>
         <Flex className={styles.column} column>


### PR DESCRIPTION
Fixes [CH1315](https://app.clubhouse.io/learnersguild/story/1315/missing-project-level-xp-in-player-stats-ui)

## Overview

XP was being nulled out in the UI. Not sure why. ELO was as well and
that seems inconsistent to me, so I'm showing the diff about your elo
changed for this project just like we do for XP.

## Data Model / DB Schema Changes

nope

## Environment / Configuration Changes

nooo

## Notes

Also fixing lint errors from a previous commit.
