### PR TITLE
Custom error typing refactor

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
   "presets": ["es2015", "stage-2", "react"],
   "plugins": [
     "add-module-exports",
+    ["transform-builtin-extend", {"globals": ["Error"]}]
   ],
   "env": {
     "test": {

--- a/common/components/__tests__/SurveyFormInputRadio.test.js
+++ b/common/components/__tests__/SurveyFormInputRadio.test.js
@@ -12,6 +12,7 @@ describe(testContext(__filename), function () {
   let changedValue = null
 
   const props = {
+    name: 'mahRadioInput',
     options: [
       {value: 100, label: 'hmkay, #1'},
       {value: 200, label: 'hrmkay, #2'},

--- a/common/components/__tests__/SurveyFormInputSliderGroup.test.js
+++ b/common/components/__tests__/SurveyFormInputSliderGroup.test.js
@@ -12,6 +12,7 @@ describe(testContext(__filename), function () {
   // let changedValue = null
 
   const props = {
+    name: 'mahSliderGroupInput',
     hint: 'do all the things',
     sum: 200,
     options: [

--- a/common/components/__tests__/SurveyFormInputText.test.js
+++ b/common/components/__tests__/SurveyFormInputText.test.js
@@ -12,6 +12,7 @@ describe(testContext(__filename), function () {
   let changedValue = null
 
   const props = {
+    name: 'mahTextInput',
     hint: 'this is the hint!',
     value: 'hmmkay.',
     onChange: value => {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -548,6 +548,11 @@
       "from": "babel-plugin-transform-async-to-generator@>=6.22.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.22.0.tgz"
     },
+    "babel-plugin-transform-builtin-extend": {
+      "version": "1.1.2",
+      "from": "babel-plugin-transform-builtin-extend@latest",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-builtin-extend/-/babel-plugin-transform-builtin-extend-1.1.2.tgz"
+    },
     "babel-plugin-transform-class-properties": {
       "version": "6.22.0",
       "from": "babel-plugin-transform-class-properties@>=6.22.0 <7.0.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "babel-core": "^6.20.0",
     "babel-loader": "^6.2.9",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-polyfill": "^6.20.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",

--- a/server/util/__tests__/error.test.js
+++ b/server/util/__tests__/error.test.js
@@ -5,29 +5,38 @@ import {GraphQLError} from 'graphql/error'
 
 import {
   LGCustomQueryError,
+  LGNotAuthorizedError,
   formatServerError,
 } from '../error'
 
 describe(testContext(__filename), function () {
   describe('formatServerError()', function () {
-    it('Error: 500 status code, internal server error, masked message', function () {
-      const original = new Error('Wat')
-      const formatted = formatServerError(original)
-      _validateError(formatted, 'An internal server error occurred', 500)
-    })
-
-    it('LGCustomQueryError: 400 status code, bad request, original message', function () {
+    it('LGCustomQueryError: 400 status code, original message', function () {
       const message = 'Hey there hi there ho there'
       const original = new LGCustomQueryError(message)
       const formatted = formatServerError(original)
       _validateError(formatted, message, 400)
+    })
+
+    it('LGNotAuthorizedError: 401 status code, original message', function () {
+      const message = 'Hey there hi there ho there'
+      const original = new LGNotAuthorizedError(message)
+      const formatted = formatServerError(original)
+      _validateError(formatted, message, 401)
+    })
+
+    it('GraphQLError: 500 status code, internal server error, masked message, original error', function () {
+      const original = new GraphQLError('Hay itz me')
+      const formatted = formatServerError(original)
+      _validateError(formatted, 'An internal server error occurred', 500)
       expect(formatted.originalError).to.deep.equal(original)
     })
 
-    it('GraphQLError: original error', function () {
-      const original = new GraphQLError('Hay itz me')
+    it('Error: 500 status code, internal server error, masked message', function () {
+      const original = new Error('Wat')
       const formatted = formatServerError(original)
-      expect(formatted).to.deep.equal(original)
+      _validateError(formatted, 'An internal server error occurred', 500)
+      expect(formatted.originalError).to.deep.equal(original)
     })
   })
 })


### PR DESCRIPTION
Fixes [ch1457](https://app.clubhouse.io/learnersguild/story/1457).

## Overview

Fixes 2 issues with improperly logging external user errors:

1. Limitations w/ out-of-the-box `babel-node` were preventing full extension of the built-in `Error` type.
2. Some errors of custom types were being wrapped again in a plain `Error` instance, preventing them from being detected (via `error.statusCode`) as external errors that should not be captured in Sentry.

Main changes:
- add `babel-plugin-transform-builtin-extend` dependency
- simplify error customization; consolidate logic into parent `LGError` class
- simplify `server/util/error`'s `formatServerError()` switch handling

Other (unrelated) changes:
- fix warnings for survey form input component tests

References:
- http://stackoverflow.com/questions/33870684/why-doesnt-instanceof-work-on-instances-of-error-subclasses-under-babel-node

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

Updated dependencies:
```
$ npm update
```

