### PR TITLE
Server error handling updates

### DIFF
--- a/common/actions/app.js
+++ b/common/actions/app.js
@@ -16,12 +16,12 @@ export function fetchDataSuccess() {
   return {type: FETCH_DATA_SUCCESS}
 }
 
-export function fetchDataFailure(error) {
-  return {type: FETCH_DATA_FAILURE, error}
+export function fetchDataFailure(message) {
+  return {type: FETCH_DATA_FAILURE, message}
 }
 
-export function authorizationError(error) {
-  return {type: AUTHORIZATION_ERROR, error}
+export function authorizationError(message) {
+  return {type: AUTHORIZATION_ERROR, message}
 }
 
 export function dismissError(index) {

--- a/common/reducers/app.js
+++ b/common/reducers/app.js
@@ -33,11 +33,11 @@ export default function app(state = initialState, action) {
     case FETCH_DATA_FAILURE:
     case UNLOCK_SURVEY_FAILURE:
       {
-        console.error(action.type, action.error)
+        console.error(action.type, action.message)
         return {
           ...state,
           isBusy: false,
-          errors: appendErrorMessage(state, action.error),
+          errors: appendErrorMessage(state, action.message),
         }
       }
 
@@ -51,8 +51,8 @@ export default function app(state = initialState, action) {
   }
 }
 
-function appendErrorMessage(state, errorMessage) {
-  return [...state.errors, errorMessage]
+function appendErrorMessage(state, message) {
+  return [...state.errors, message]
 }
 
 function removeErrorMessage(state, errorMessageIndex) {

--- a/server/actions/assertCycleInState.js
+++ b/server/actions/assertCycleInState.js
@@ -1,14 +1,13 @@
-import {GraphQLError} from 'graphql/error'
-
 import {getCycleById} from 'src/server/db/cycle'
+import {LGBadInputError, LGForbiddenError} from 'src/server/util/error'
 
 export default async function assertCycleInState(cycleIdentifier, state) {
   const cycle = typeof cycleIdentifier === 'string' ? await getCycleById(cycleIdentifier) : cycleIdentifier
   if (!cycle || !cycle.state) {
-    throw new GraphQLError(`Cycle not found for identifier ${cycleIdentifier}`)
+    throw new LGBadInputError(`Cycle not found for identifier ${cycleIdentifier}`)
   }
   const cycleStates = Array.isArray(state) ? state : [state]
   if (!cycleStates.includes(cycle.state)) {
-    throw new GraphQLError(`This action is not allowed when the cycle is in the ${cycle.state} state`)
+    throw new LGForbiddenError(`This action is not allowed when the cycle is in the ${cycle.state} state`)
   }
 }

--- a/server/actions/assertPlayersCurrentCycleInState.js
+++ b/server/actions/assertPlayersCurrentCycleInState.js
@@ -1,13 +1,12 @@
-import {GraphQLError} from 'graphql/error'
-
 import {getLatestCycleForChapter} from 'src/server/db/cycle'
 import {getPlayerById} from 'src/server/db/player'
+import {LGForbiddenError} from 'src/server/util/error'
 
 export default async function assertPlayersCurrentCycleInState(currentUser, state) {
   const player = await getPlayerById(currentUser.id, {mergeChapter: true})
   const cycleInReflection = await getLatestCycleForChapter(player.chapter.id)('state').eq(state)
 
   if (!cycleInReflection) {
-    throw new GraphQLError(`This action is not allowed when the cycle is not in the ${state} state`)
+    throw new LGForbiddenError(`This action is not allowed when the cycle is not in the ${state} state`)
   }
 }

--- a/server/graphql/mutations/createCycle.js
+++ b/server/graphql/mutations/createCycle.js
@@ -1,10 +1,10 @@
 import {GraphQLInt} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import {getModeratorById} from 'src/server/db/moderator'
 import createNextCycleForChapter from 'src/server/actions/createNextCycleForChapter'
 import {Cycle} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError, LGForbiddenError} from 'src/server/util/error'
 
 export default {
   type: Cycle,
@@ -13,15 +13,15 @@ export default {
   },
   async resolve(source, {projectDefaultExpectedHours}, {rootValue: {currentUser}}) {
     if (!userCan(currentUser, 'createCycle')) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const moderator = await getModeratorById(currentUser.id)
     if (!moderator) {
-      throw new GraphQLError('You are not a moderator for the game.')
+      throw new LGNotAuthorizedError('You are not a moderator for the game.')
     }
     if (!moderator.chapterId) {
-      throw new GraphQLError('You must be assigned to a chapter to start a new cycle.')
+      throw new LGForbiddenError('You must be assigned to a chapter to start a new cycle.')
     }
 
     return await createNextCycleForChapter(moderator.chapterId, projectDefaultExpectedHours)

--- a/server/graphql/mutations/createOrUpdateChapter.js
+++ b/server/graphql/mutations/createOrUpdateChapter.js
@@ -1,10 +1,10 @@
 import {GraphQLNonNull} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import {chapterSchema} from 'src/common/validations'
 import {saveChapter} from 'src/server/db/chapter'
 import {Chapter, InputChapter} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError, LGInternalServerError} from 'src/server/util/error'
 
 export default {
   type: Chapter,
@@ -13,7 +13,7 @@ export default {
   },
   async resolve(source, {chapter}, {rootValue: {currentUser}}) {
     if (chapter.id && !userCan(currentUser, 'updateChapter') || !chapter.id && !userCan(currentUser, 'createChapter')) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     await chapterSchema.validate(chapter) // validation error will be thrown if invalid
@@ -23,6 +23,6 @@ export default {
       return result.changes[0].new_val
     }
 
-    throw new GraphQLError('Could not save chapter, please try again')
+    throw new LGInternalServerError('Could not save chapter, please try again')
   }
 }

--- a/server/graphql/mutations/importProject.js
+++ b/server/graphql/mutations/importProject.js
@@ -1,9 +1,9 @@
 import {GraphQLNonNull} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import importProject from 'src/server/actions/importProject'
 import {Project, ProjectImport} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: Project,
@@ -12,7 +12,7 @@ export default {
   },
   async resolve(source, {values}, {rootValue: {currentUser}}) {
     if (!userCan(currentUser, 'importProject')) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     return await importProject(values, {initializeChannel: true})

--- a/server/graphql/mutations/lockRetroSurveyForUser.js
+++ b/server/graphql/mutations/lockRetroSurveyForUser.js
@@ -1,8 +1,8 @@
 import {GraphQLNonNull, GraphQLID} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 import {lockRetroSurveyForUser} from 'src/server/actions/retroSurveyLockUnlock'
 import userCan from 'src/common/util/userCan'
 import {Project} from 'src/server/services/dataService/models'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 import {ProjectSummary} from 'src/server/graphql/schemas'
 
@@ -20,7 +20,7 @@ export default {
   },
   async resolve(source, {playerId, projectId}, {rootValue: {currentUser}}) {
     if (!userCan(currentUser, 'lockAndUnlockSurveys')) {
-      throw new GraphQLError('You are not authorized to do that')
+      throw new LGNotAuthorizedError()
     }
 
     await lockRetroSurveyForUser(playerId, projectId)

--- a/server/graphql/mutations/reassignPlayersToChapter.js
+++ b/server/graphql/mutations/reassignPlayersToChapter.js
@@ -1,11 +1,11 @@
 import {GraphQLNonNull, GraphQLID} from 'graphql'
 import {GraphQLList} from 'graphql/type'
-import {GraphQLError} from 'graphql/error'
 
 import {connect} from 'src/db'
 import {userCan} from 'src/common/util'
 import {reassignPlayersToChapter} from 'src/server/db/player'
 import {User} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError, LGBadInputError} from 'src/server/util/error'
 
 const r = connect()
 
@@ -17,12 +17,12 @@ export default {
   },
   async resolve(source, {playerIds, chapterId}, {rootValue: {currentUser}}) {
     if (!userCan(currentUser, 'reassignPlayersToChapter')) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const chapter = await r.table('chapters').get(chapterId).run()
     if (!chapter) {
-      throw new GraphQLError('No such chapter.')
+      throw new LGBadInputError('No such chapter.')
     }
 
     return await reassignPlayersToChapter(playerIds, chapterId)

--- a/server/graphql/mutations/setProjectArtifactURL.js
+++ b/server/graphql/mutations/setProjectArtifactURL.js
@@ -1,10 +1,10 @@
 import {GraphQLNonNull, GraphQLString} from 'graphql'
 import {GraphQLURL} from 'graphql-custom-types'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import {update as updateProject, findProjectByNameForPlayer} from 'src/server/db/project'
 import {Project} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError, LGInternalServerError} from 'src/server/util/error'
 
 export default {
   type: Project,
@@ -14,7 +14,7 @@ export default {
   },
   async resolve(source, {projectName, url}, {rootValue: {currentUser}}) {
     if (!userCan(currentUser, 'setProjectArtifact')) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const project = await findProjectByNameForPlayer(projectName, currentUser.id)
@@ -25,6 +25,6 @@ export default {
       return result.changes[0].new_val
     }
 
-    throw new GraphQLError('Failed to update project artifactURL')
+    throw new LGInternalServerError('Failed to update project artifactURL')
   }
 }

--- a/server/graphql/mutations/unlockRetroSurveyForUser.js
+++ b/server/graphql/mutations/unlockRetroSurveyForUser.js
@@ -1,8 +1,8 @@
 import {GraphQLNonNull, GraphQLID} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 import {unlockRetroSurveyForUser} from 'src/server/actions/retroSurveyLockUnlock'
 import userCan from 'src/common/util/userCan'
 import {Project} from 'src/server/services/dataService/models'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 import {ProjectSummary} from 'src/server/graphql/schemas'
 
@@ -20,7 +20,7 @@ export default {
   },
   async resolve(source, {playerId, projectId}, {rootValue: {currentUser}}) {
     if (!userCan(currentUser, 'lockAndUnlockSurveys')) {
-      throw new GraphQLError('You are not authorized to do that')
+      throw new LGNotAuthorizedError()
     }
 
     await unlockRetroSurveyForUser(playerId, projectId)

--- a/server/graphql/mutations/updateCycleState.js
+++ b/server/graphql/mutations/updateCycleState.js
@@ -1,5 +1,4 @@
 import {GraphQLNonNull, GraphQLString} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import {CYCLE_STATES} from 'src/common/models/cycle'
@@ -7,6 +6,7 @@ import {getModeratorById} from 'src/server/db/moderator'
 import {getCyclesInStateForChapter} from 'src/server/db/cycle'
 import updateCycleState from 'src/server/actions/updateCycleState'
 import {Cycle} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError, LGBadInputError, LGForbiddenError} from 'src/server/util/error'
 
 export default {
   type: Cycle,
@@ -21,23 +21,23 @@ export default {
 async function changeCycleState(newState, currentUser) {
   const newStateIndex = CYCLE_STATES.indexOf(newState)
   if (!userCan(currentUser, 'updateCycle')) {
-    throw new GraphQLError('You are not authorized to do that')
+    throw new LGNotAuthorizedError()
   }
   if (newStateIndex === -1) {
-    throw new GraphQLError(`Invalid cycle state ${newState}`)
+    throw new LGBadInputError(`Invalid cycle state ${newState}`)
   }
   if (newStateIndex === 0) {
-    throw new GraphQLError(`You cannot change the cycle state back to ${newState}`)
+    throw new LGForbiddenError(`You cannot change the cycle state back to ${newState}`)
   }
 
   const moderator = await getModeratorById(currentUser.id, {mergeChapter: true})
   if (!moderator) {
-    throw new GraphQLError('You are not a moderator for the game')
+    throw new LGNotAuthorizedError('You are not a moderator for the game')
   }
   const validOriginState = CYCLE_STATES[newStateIndex - 1]
   const cycles = await getCyclesInStateForChapter(moderator.chapter.id, validOriginState)
   if (!cycles.length > 0) {
-    throw new GraphQLError(`No cycles for ${moderator.chapter.name} chapter (${moderator.chapter.id}) in ${validOriginState} state`)
+    throw new LGForbiddenError(`No cycles for ${moderator.chapter.name} chapter (${moderator.chapter.id}) in ${validOriginState} state`)
   }
 
   return updateCycleState(cycles[0], newState)

--- a/server/graphql/queries/findMyProjects.js
+++ b/server/graphql/queries/findMyProjects.js
@@ -1,15 +1,15 @@
 import {GraphQLList} from 'graphql/type'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import {findProjectsForUser} from 'src/server/db/project'
 import {Project} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: new GraphQLList(Project),
   async resolve(source, args = {}, {rootValue: {currentUser}}) {
     if (!userCan(currentUser, 'findProjects')) {
-      throw new GraphQLError('You are not authorized to do that')
+      throw new LGNotAuthorizedError()
     }
     return findProjectsForUser(currentUser.id)
   },

--- a/server/graphql/queries/findProjects.js
+++ b/server/graphql/queries/findProjects.js
@@ -1,10 +1,10 @@
 import {GraphQLString} from 'graphql'
 import {GraphQLList} from 'graphql/type'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import {findProjects} from 'src/server/db/project'
 import {Project} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: new GraphQLList(Project),
@@ -13,7 +13,7 @@ export default {
   },
   async resolve(source, args = {}, {rootValue: {currentUser}}) {
     if (!userCan(currentUser, 'findProjects')) {
-      throw new GraphQLError('You are not authorized to do that')
+      throw new LGNotAuthorizedError()
     }
     return findProjects(args.identifiers)
   },

--- a/server/graphql/queries/findRetrospectiveSurveys.js
+++ b/server/graphql/queries/findRetrospectiveSurveys.js
@@ -1,15 +1,15 @@
 import {GraphQLList} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import findOpenRetroSurveysForPlayer from 'src/server/actions/findOpenRetroSurveysForPlayer'
 import {Survey} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: new GraphQLList(Survey),
   async resolve(source, args, {rootValue: {currentUser}}) {
     if (!currentUser || !userCan(currentUser, 'findRetrospectiveSurveys')) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     return findOpenRetroSurveysForPlayer(currentUser.id)

--- a/server/graphql/queries/findUsers.js
+++ b/server/graphql/queries/findUsers.js
@@ -1,10 +1,10 @@
 import {GraphQLString} from 'graphql'
 import {GraphQLList} from 'graphql/type'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import findUsers from 'src/server/actions/findUsers'
 import {UserProfile} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: new GraphQLList(UserProfile),
@@ -13,7 +13,7 @@ export default {
   },
   async resolve(source, {identifiers}, {rootValue: {currentUser}}) {
     if (!userCan(currentUser, 'findUsers')) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     return await findUsers(identifiers, {skipNoMatch: true})

--- a/server/graphql/queries/getAllChapters.js
+++ b/server/graphql/queries/getAllChapters.js
@@ -1,8 +1,8 @@
 import {GraphQLList} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {connect} from 'src/db'
 import {Chapter} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 const r = connect()
 
@@ -10,7 +10,7 @@ export default {
   type: new GraphQLList(Chapter),
   async resolve(source, args, {rootValue: {currentUser}}) {
     if (!currentUser) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     return await r.table('chapters').run()

--- a/server/graphql/queries/getAllCycles.js
+++ b/server/graphql/queries/getAllCycles.js
@@ -1,8 +1,8 @@
 import {GraphQLList} from 'graphql/type'
-import {GraphQLError} from 'graphql/error'
 
 import {connect} from 'src/db'
 import {Cycle} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 const r = connect()
 
@@ -10,7 +10,7 @@ export default {
   type: new GraphQLList(Cycle),
   async resolve(source, args, {rootValue: {currentUser}}) {
     if (!currentUser) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const result = await r.table('cycles')

--- a/server/graphql/queries/getAllPlayers.js
+++ b/server/graphql/queries/getAllPlayers.js
@@ -1,8 +1,8 @@
 import {GraphQLList} from 'graphql/type'
-import {GraphQLError} from 'graphql/error'
 
 import {connect} from 'src/db'
 import {User} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 const r = connect()
 
@@ -10,7 +10,7 @@ export default {
   type: new GraphQLList(User),
   async resolve(source, args, {rootValue: {currentUser}}) {
     if (!currentUser) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     return await r.table('players')

--- a/server/graphql/queries/getChapterById.js
+++ b/server/graphql/queries/getChapterById.js
@@ -1,8 +1,8 @@
 import {GraphQLNonNull, GraphQLID} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {connect} from 'src/db'
 import {Chapter} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError, LGBadInputError} from 'src/server/util/error'
 
 const r = connect()
 
@@ -13,7 +13,7 @@ export default {
   },
   async resolve(source, args, {rootValue: {currentUser}}) {
     if (!currentUser) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const result = await r.table('chapters').get(args.id).run()
@@ -21,6 +21,6 @@ export default {
       return result
     }
 
-    throw new GraphQLError('No such chapter')
+    throw new LGBadInputError('No such chapter')
   }
 }

--- a/server/graphql/queries/getCycleById.js
+++ b/server/graphql/queries/getCycleById.js
@@ -1,8 +1,8 @@
 import {GraphQLNonNull, GraphQLID} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {getCycleById} from 'src/server/db/cycle'
 import {Cycle} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: Cycle,
@@ -11,7 +11,7 @@ export default {
   },
   async resolve(source, args, {rootValue: {currentUser}}) {
     if (!currentUser) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const result = await getCycleById(args.id, {mergeChapter: true})

--- a/server/graphql/queries/getCycleVotingResults.js
+++ b/server/graphql/queries/getCycleVotingResults.js
@@ -1,11 +1,11 @@
 import {GraphQLID} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {getPlayerById} from 'src/server/db/player'
 import {getModeratorById} from 'src/server/db/moderator'
 import {customQueryError} from 'src/server/db/errors'
 import getCycleVotingResults from 'src/server/actions/getCycleVotingResults'
 import {CycleVotingResults} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: CycleVotingResults,
@@ -15,7 +15,7 @@ export default {
   async resolve(source, {cycleId}, {rootValue: {currentUser}}) {
     // only signed-in users can view results
     if (!currentUser) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const user = await getPlayerById(currentUser.id)

--- a/server/graphql/queries/getPlayerById.js
+++ b/server/graphql/queries/getPlayerById.js
@@ -1,8 +1,8 @@
 import {GraphQLNonNull, GraphQLID} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {getPlayerById} from 'src/server/db/player'
 import {User} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError, LGBadInputError} from 'src/server/util/error'
 
 export default {
   type: User,
@@ -11,7 +11,7 @@ export default {
   },
   async resolve(source, args, {rootValue: {currentUser}}) {
     if (!currentUser) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const result = await getPlayerById(args.id, {mergeChapter: true})
@@ -19,6 +19,6 @@ export default {
       return result
     }
 
-    throw new GraphQLError('No such player')
+    throw new LGBadInputError('No such player')
   },
 }

--- a/server/graphql/queries/getProject.js
+++ b/server/graphql/queries/getProject.js
@@ -1,9 +1,9 @@
 import {GraphQLNonNull, GraphQLString} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import {getProject} from 'src/server/db/project'
 import {Project} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError, LGBadInputError} from 'src/server/util/error'
 
 export default {
   type: Project,
@@ -12,12 +12,12 @@ export default {
   },
   async resolve(source, {identifier}, {rootValue: {currentUser}}) {
     if (!userCan(currentUser, 'viewProject')) {
-      throw new GraphQLError('You are not authorized to do that')
+      throw new LGNotAuthorizedError()
     }
 
     const project = await getProject(identifier)
     if (!project) {
-      throw new GraphQLError(`Project not found for identifier ${identifier}`)
+      throw new LGBadInputError(`Project not found for identifier ${identifier}`)
     }
 
     return project

--- a/server/graphql/queries/getProjectReviewSurveyStatus.js
+++ b/server/graphql/queries/getProjectReviewSurveyStatus.js
@@ -1,9 +1,9 @@
 import {GraphQLString, GraphQLNonNull} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import getProjectReviewStatusForPlayer from 'src/server/actions/getProjectReviewStatusForPlayer'
 import {ProjectReviewSurveyStatus} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: ProjectReviewSurveyStatus,
@@ -12,7 +12,7 @@ export default {
   },
   resolve(source, {projectName}, {rootValue: {currentUser}}) {
     if (!currentUser || !userCan(currentUser, 'getProjectReviewSurveyStatus')) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     return getProjectReviewStatusForPlayer(projectName, currentUser.id)

--- a/server/graphql/queries/getProjectSummary.js
+++ b/server/graphql/queries/getProjectSummary.js
@@ -1,9 +1,9 @@
 import {GraphQLNonNull, GraphQLString} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import {getProject} from 'src/server/db/project'
 import {ProjectSummary} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError, LGBadInputError} from 'src/server/util/error'
 
 export default {
   type: ProjectSummary,
@@ -12,12 +12,12 @@ export default {
   },
   async resolve(source, {identifier}, {rootValue: {currentUser}}) {
     if (!userCan(currentUser, 'viewProjectSummary')) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const project = await getProject(identifier)
     if (!project) {
-      throw new GraphQLError(`Project not found for identifier ${identifier}`)
+      throw new LGBadInputError(`Project not found for identifier ${identifier}`)
     }
 
     return {project}

--- a/server/graphql/queries/getProjectSummaryForPlayer.js
+++ b/server/graphql/queries/getProjectSummaryForPlayer.js
@@ -1,15 +1,14 @@
-import {GraphQLError} from 'graphql/error'
-
 import {getLatestCycleForChapter} from 'src/server/db/cycle'
 import {getUserById} from 'src/server/db/user'
 import {findProjectsForUser, findProjects} from 'src/server/db/project'
 import {ProjectsSummary} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: ProjectsSummary,
   async resolve(source, args, {rootValue: {currentUser}}) {
     if (!currentUser) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const user = await getUserById(currentUser.id, {mergeChapter: true})

--- a/server/graphql/queries/getProjectsAndReviewResponsesForPlayer.js
+++ b/server/graphql/queries/getProjectsAndReviewResponsesForPlayer.js
@@ -1,16 +1,16 @@
-import {GraphQLError} from 'graphql/error'
 import {GraphQLList} from 'graphql/type'
 
 import {getLatestCycleForChapter} from 'src/server/db/cycle'
 import {getUserById} from 'src/server/db/user'
 import {findProjectsAndReviewResponsesForPlayer} from 'src/server/db/project'
 import {ProjectWithReviewResponses} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: new GraphQLList(ProjectWithReviewResponses),
   async resolve(source, args, {rootValue: {currentUser}}) {
     if (!currentUser) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const user = await getUserById(currentUser.id, {mergeChapter: true})

--- a/server/graphql/queries/getRetrospectiveSurvey.js
+++ b/server/graphql/queries/getRetrospectiveSurvey.js
@@ -1,10 +1,10 @@
 import {GraphQLString} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import {getProjectByName} from 'src/server/db/project'
 import {compileSurveyDataForPlayer} from 'src/server/actions/compileSurveyData'
 import {Survey} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: Survey,
@@ -16,7 +16,7 @@ export default {
   },
   async resolve(source, {projectName}, {rootValue: {currentUser}}) {
     if (!currentUser || !userCan(currentUser, 'getRetrospectiveSurvey')) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const projectId = projectName ? await getProjectByName(projectName)('id') : undefined

--- a/server/graphql/queries/getRetrospectiveSurveyQuestion.js
+++ b/server/graphql/queries/getRetrospectiveSurveyQuestion.js
@@ -1,10 +1,10 @@
 import {GraphQLInt, GraphQLString, GraphQLNonNull} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import {getProjectByName} from 'src/server/db/project'
 import {compileSurveyQuestionDataForPlayer} from 'src/server/actions/compileSurveyData'
 import {SurveyQuestion} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: SurveyQuestion,
@@ -19,7 +19,7 @@ export default {
   },
   async resolve(source, {questionNumber, projectName}, {rootValue: {currentUser}}) {
     if (!currentUser || !userCan(currentUser, 'getRetrospectiveSurvey')) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const projectId = projectName ? await getProjectByName(projectName)('id') : undefined

--- a/server/graphql/queries/getUserById.js
+++ b/server/graphql/queries/getUserById.js
@@ -1,8 +1,8 @@
 import {GraphQLNonNull, GraphQLID} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {getUserById} from 'src/server/db/user'
 import {User} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError, LGBadInputError} from 'src/server/util/error'
 
 export default {
   type: User,
@@ -11,13 +11,13 @@ export default {
   },
   async resolve(source, {id}, {rootValue: {currentUser}}) {
     if (!currentUser) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     const result = await getUserById(id, {mergeChapter: true})
     if (result) {
       return result
     }
-    throw new GraphQLError('No such user')
+    throw new LGBadInputError('No such user')
   }
 }

--- a/server/graphql/queries/getUserSummary.js
+++ b/server/graphql/queries/getUserSummary.js
@@ -1,9 +1,9 @@
 import {GraphQLNonNull, GraphQLString} from 'graphql'
-import {GraphQLError} from 'graphql/error'
 
 import {userCan} from 'src/common/util'
 import {resolveUser} from 'src/server/graphql/resolvers'
 import {UserSummary} from 'src/server/graphql/schemas'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: UserSummary,
@@ -12,7 +12,7 @@ export default {
   },
   async resolve(source, args, ast) {
     if (!userCan(ast.rootValue.currentUser, 'viewUserSummary')) {
-      throw new GraphQLError('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
 
     return {

--- a/server/jobQueuesUI.js
+++ b/server/jobQueuesUI.js
@@ -4,6 +4,7 @@ import toureiro from 'toureiro'
 
 import config from 'src/config'
 import {userCan} from 'src/common/util'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 const app = new express.Router()
 const redisConfig = url.parse(config.server.redis.url)
@@ -20,7 +21,7 @@ app.use(
   '/job-queues',
   (req, res, next) => {
     if (!req.user || !userCan(req.user, 'monitorJobQueues')) {
-      throw new Error('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
     next()
   },

--- a/server/reports/index.js
+++ b/server/reports/index.js
@@ -1,6 +1,7 @@
 import express from 'express'
 
 import {userCan} from 'src/common/util'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 import logger from 'src/server/util/logger'
 
 const app = new express.Router()
@@ -37,7 +38,7 @@ function requestHandler(req, res, next) {
 function assertUserCanViewReport(user, reportName) {
   if (SENSITIVE_REPORTS.includes(reportName)) {
     if (!user || !userCan(user, 'viewSensitiveReports')) {
-      throw new Error('You are not authorized to do that.')
+      throw new LGNotAuthorizedError()
     }
   }
 }

--- a/server/util/__tests__/error.test.js
+++ b/server/util/__tests__/error.test.js
@@ -4,8 +4,10 @@
 import {GraphQLError} from 'graphql/error'
 
 import {
+  LGBadInputError,
   LGCustomQueryError,
   LGNotAuthorizedError,
+  LGTokenExpiredError,
   formatServerError,
 } from '../error'
 
@@ -18,9 +20,23 @@ describe(testContext(__filename), function () {
       _validateError(formatted, message, 400)
     })
 
+    it('LGBadInputError: 400 status code, original message', function () {
+      const message = 'Whoa nelly...no bueno'
+      const original = new LGBadInputError(message)
+      const formatted = formatServerError(original)
+      _validateError(formatted, message, 400)
+    })
+
     it('LGNotAuthorizedError: 401 status code, original message', function () {
-      const message = 'Hey there hi there ho there'
+      const message = 'Hold it right there, partner'
       const original = new LGNotAuthorizedError(message)
+      const formatted = formatServerError(original)
+      _validateError(formatted, message, 401)
+    })
+
+    it('LGTokenExpiredError: 401 status code, original message', function () {
+      const message = 'Nope nope nope'
+      const original = new LGTokenExpiredError(message)
       const formatted = formatServerError(original)
       _validateError(formatted, message, 401)
     })

--- a/server/util/error.js
+++ b/server/util/error.js
@@ -77,18 +77,18 @@ export class LGInternalServerError extends LGError {
   }
 }
 
-export function formatServerError(origError) {
-  const error = parseQueryError(origError)
+export function formatServerError(error) {
+  const parsedError = parseQueryError(error && error.originalError ? error.originalError : error)
 
-  if (error instanceof LGError) {
-    return error
+  if (parsedError instanceof LGError) {
+    return parsedError
   }
-  if (error.name === 'BadRequestError') {
-    return new LGBadInputError(origError)
+  if (parsedError.name === 'BadRequestError') {
+    return new LGBadInputError(parsedError)
   }
-  if (error.name === 'TokenExpiredError') {
-    return new LGTokenExpiredError(origError)
+  if (parsedError.name === 'TokenExpiredError') {
+    return new LGTokenExpiredError(parsedError)
   }
 
-  return new LGInternalServerError(error)
+  return new LGInternalServerError(parsedError)
 }


### PR DESCRIPTION
Fixes [ch1457](https://app.clubhouse.io/learnersguild/story/1457).
Fixes #196.
Fixes #665.

## Overview

More error handling updates:
- errors captured by `express-graphql` and passed into `formatError` function option are wrapped in a generic error object; extract the wrapped original error for inspection if present
- use custom error types in more places where appropriate

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.
