### PR TITLE
Set default state for imported projects

### DIFF
--- a/server/services/dataService/models/project.js
+++ b/server/services/dataService/models/project.js
@@ -42,7 +42,6 @@ export default function projectModel(thinky) {
         .allowNull(false),
 
       state: string()
-        .min(1)
         .allowNull(false)
         .default(PROJECT_STATES.IN_PROGRESS),
 


### PR DESCRIPTION
Fixes [ch1512](https://app.clubhouse.io/learnersguild/story/ch1512).

- sets default state to `IN_PROGRESS` (via model def) for all newly created projects

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.