### PR TITLE
fix display of 0 ratings in reviews

### DIFF
--- a/common/components/ProjectDetail/index.jsx
+++ b/common/components/ProjectDetail/index.jsx
@@ -140,8 +140,12 @@ class ProjectDetail extends Component {
     const projectEvaluationRows = (projectEvaluations || []).map(evaluation => {
       const user = evaluation.submittedBy || {}
       return {
-        completeness: evaluation[STAT_DESCRIPTORS.PROJECT_COMPLETENESS],
-        quality: evaluation[STAT_DESCRIPTORS.PROJECT_QUALITY],
+        // Due to a bug in Table in react toolbox "falsy" values are not displayed if the
+        // table is not editable. So we have to conver these stats to strings to make sure that
+        // 0 gets displayed properly. =(
+        completeness: evaluation[STAT_DESCRIPTORS.PROJECT_COMPLETENESS].toString(),
+        quality: evaluation[STAT_DESCRIPTORS.PROJECT_QUALITY].toString(),
+
         submittedByHandle: user.handle,
         submittedByName: user.name,
       }


### PR DESCRIPTION
Fixes [ch1843](https://app.clubhouse.io/learnersguild/story/1843)

## Overview

Due to a bug in Table in react toolbox "falsy" values are not displayed
if the table is not editable. So we have to convert these stats to strings
to make sure that 0 gets displayed properly. =(

See:
https://github.com/react-toolbox/react-toolbox/blob/1.3.4/components/table/TableRow.js#L69-L71

## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

none

## Notes

none
