### PR TITLE
show project reviews once the project has closed

### DIFF
--- a/server/graphql/resolvers/index.js
+++ b/server/graphql/resolvers/index.js
@@ -136,7 +136,11 @@ export async function resolveProjectEvaluations(projectSummary, args, {rootValue
     await findProjectEvaluations(project),
     'submittedById',
     'submittedBy'
-  ).filter(({submittedById}) => submittedById === currentUser.id || userCan(currentUser, 'viewProjectEvaluation'))
+  ).filter(({submittedById}) => (
+    project.state === PROJECT_STATES.CLOSED ||
+    submittedById === currentUser.id ||
+    userCan(currentUser, 'viewProjectEvaluation')
+  ))
 }
 
 export async function resolveProjectUserSummaries(projectSummary, args, {rootValue: {currentUser}}) {


### PR DESCRIPTION
Fixes [ch1496](https://app.clubhouse.io/learnersguild/story/1496)

## Overview

Loosening the permissions arounf project reviews to make them visible to everyone after a project has been "closed".

## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

none

## Notes

nope
