### PR TITLE
Return error for `deleteProject` when project not in IN_PROGRESS state

### DIFF
--- a/server/actions/__tests__/deleteProject.test.js
+++ b/server/actions/__tests__/deleteProject.test.js
@@ -1,0 +1,33 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+import factory from 'src/test/factories'
+import {withDBCleanup} from 'src/test/helpers'
+import {Project} from 'src/server/services/dataService'
+import {PROJECT_STATES} from 'src/common/models/project'
+
+import deleteProject from '../deleteProject'
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+
+  it('resolves successfully the 1st time and throws an error if attempted a 2nd time', async function () {
+    const project = await factory.create('project', {state: PROJECT_STATES.IN_PROGRESS})
+    const result = await deleteProject(project.id)
+    expect(result).to.eq(null)
+
+    const deletedProject = Project.get(project.id)
+    return expect(deletedProject).to.eventually.be.rejectedWith(/returned null/i)
+  })
+
+  it('throws an error if project not found', async function () {
+    const result = deleteProject('fake.id')
+    return expect(result).to.eventually.be.rejectedWith(/not found/i)
+  })
+
+  it('throws an error if project is not in IN_PROGRESS state', async function () {
+    const project = await factory.create('project', {state: PROJECT_STATES.CLOSED})
+    const result = deleteProject(project.id)
+    return expect(result).to.eventually.be.rejectedWith(/Project can only be deleted if still in progress/i)
+  })
+})

--- a/server/actions/deleteProject.js
+++ b/server/actions/deleteProject.js
@@ -1,0 +1,18 @@
+import {PROJECT_STATES} from 'src/common/models/project'
+import {getProject} from 'src/server/db/project'
+import {Project} from 'src/server/services/dataService'
+import {LGBadRequestError, LGForbiddenError} from 'src/server/util/error'
+
+export default async function deleteProject(identifier) {
+  const project = await getProject(identifier)
+  if (!project) {
+    throw new LGBadRequestError('Project not found')
+  }
+
+  if (project.state !== PROJECT_STATES.IN_PROGRESS) {
+    throw new LGForbiddenError('Project can only be deleted if still in progress')
+  }
+
+  await Project.get(project.id).delete()
+  return null
+}

--- a/server/graphql/mutations/__tests__/deleteProject.test.js
+++ b/server/graphql/mutations/__tests__/deleteProject.test.js
@@ -32,16 +32,6 @@ describe(testContext(__filename), function () {
     expect(result.data.deleteProject.success).to.equal(true)
   })
 
-  it('throws an error if project is not found', function () {
-    const result = runGraphQLQuery(
-      query,
-      fields,
-      {identifier: ''},
-      {currentUser: this.currentUser},
-    )
-    return expect(result).to.eventually.be.rejectedWith(/Project not found/i)
-  })
-
   it('throws an error if user is not authorized', function () {
     const result = runGraphQLQuery(query, fields, {identifier: ''}, {currentUser: null})
     return expect(result).to.eventually.be.rejectedWith(/not authorized/i)

--- a/server/graphql/mutations/deleteProject.js
+++ b/server/graphql/mutations/deleteProject.js
@@ -1,10 +1,9 @@
 import {GraphQLNonNull, GraphQLString} from 'graphql'
 
+import deleteProject from 'src/server/actions/deleteProject'
 import {userCan} from 'src/common/util'
-import {getProject} from 'src/server/db/project'
-import {Project} from 'src/server/services/dataService'
 import {Status} from 'src/server/graphql/schemas'
-import {LGBadRequestError, LGNotAuthorizedError} from 'src/server/util/error'
+import {LGNotAuthorizedError} from 'src/server/util/error'
 
 export default {
   type: Status,
@@ -16,12 +15,7 @@ export default {
       throw new LGNotAuthorizedError('You are not authorized to delete projects.')
     }
 
-    const project = await getProject(identifier)
-    if (!project) {
-      throw new LGBadRequestError('Project not found')
-    }
-
-    await Project.get(project.id).delete()
+    await deleteProject(identifier)
     return {success: true}
   }
 }


### PR DESCRIPTION
Fixes [ch1910](https://app.clubhouse.io/learnersguild/story/1910)

## Overview

- returns an error from graphql API if `deleteProject()` request made for project not in `IN_PROGRESS` state

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.

## Notes

None.
