### PR TITLE
[HOLD] Fix `/reports` error handling

### DIFF
--- a/server/reports/index.js
+++ b/server/reports/index.js
@@ -2,13 +2,7 @@ import express from 'express'
 
 import {userCan} from 'src/common/util'
 import {LGNotAuthorizedError, LGBadRequestError} from 'src/server/util/error'
-import logger from 'src/server/util/logger'
-
-const app = new express.Router()
-
-app.get('/reports/:reportName', requestHandler)
-
-export default app
+import {writeCSV} from './util'
 
 const SENSITIVE_REPORTS = [
   'projectTeams',
@@ -20,23 +14,35 @@ const PUBLIC_REPORTS = [
   'countActivePlayersByLevel',
 ]
 
-function requestHandler(req, res, next) {
+const app = new express.Router()
+
+app.get('/reports/:reportName', async (req, res, next) => {
   const {reportName} = req.params
 
-  assertReportNameIsValid(reportName)
-  assertUserCanViewReport(req.user)
+  _assertReportNameIsValid(reportName)
+  _assertUserCanViewReport(req.user)
 
-  const reportHandler = require(`./${reportName}`)
-  const handleReport = typeof reportHandler === 'function' ? reportHandler : reportHandler.default
+  try {
+    let createReport = require(`./${reportName}`)
+    if (typeof createReport !== 'function') {
+      createReport = createReport.default
+    }
 
-  res.set('Content-Type', 'text/csv')
-  return handleReport(req, res).catch(err => {
-    logger.error(err)
-    next()
-  })
-}
+    const {rows, headers, filename} = await createReport(req, res)
+    const options = headers ? {headers} : null
 
-function assertUserCanViewReport(user, reportName) {
+    res.set('Content-Type', 'text/csv')
+    if (filename) {
+      res.setHeader('Content-disposition', `attachment; filename=${filename}`)
+    }
+
+    return writeCSV(res, rows, options)
+  } catch (err) {
+    next(err)
+  }
+})
+
+function _assertUserCanViewReport(user, reportName) {
   if (SENSITIVE_REPORTS.includes(reportName)) {
     if (!user || !userCan(user, 'viewSensitiveReports')) {
       throw new LGNotAuthorizedError()
@@ -44,9 +50,11 @@ function assertUserCanViewReport(user, reportName) {
   }
 }
 
-function assertReportNameIsValid(name) {
+function _assertReportNameIsValid(name) {
   const validReportNames = SENSITIVE_REPORTS.concat(PUBLIC_REPORTS)
   if (!validReportNames.includes(name)) {
     throw new LGBadRequestError(`Invalid report name: "${name}". Valid reports are ${validReportNames.join(', ')}`)
   }
 }
+
+export default app

--- a/server/reports/util.js
+++ b/server/reports/util.js
@@ -29,8 +29,8 @@ export async function lookupLatestCycleInChapter(chapterId) {
                 .max('cycleNumber')('cycleNumber')
 }
 
-export function writeCSV(rows, outStream, opts) {
-  const writer = csvWriter(opts || {})
+export function writeCSV(outStream, rows, options) {
+  const writer = csvWriter(options || {})
   writer.pipe(outStream)
   rows.forEach(row => writer.write(row))
   writer.end()


### PR DESCRIPTION
_**NOTE:** Being held for performance reasons. Some of the existing reports have gnarly queries that don't perform well, but we also should revert to writing one row at a time to the write stream (rather than the change here that loads the entire report into memory, where possible)._

---

Fixes [ch1923](https://app.clubhouse.io/learnersguild/story/1923)

## Overview

- consolidate req, res handling for `/reports`
- delay setting content-type header until report is successfully generated (requires more memory; might need to revisit at some point, but then,  also shouldn't _really_ be generating reports in the `game` service, anyway)

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.

