### PR TITLE
better naming of graphql transactions in newrelic

### DIFF
--- a/server/graphql/rootMutation.js
+++ b/server/graphql/rootMutation.js
@@ -1,8 +1,9 @@
 import {GraphQLObjectType} from 'graphql'
+import {instrumentResolvers} from './util'
 
 import rootFields from './mutations'
 
 export default new GraphQLObjectType({
   name: 'RootMutation',
-  fields: () => rootFields
+  fields: instrumentResolvers(rootFields, 'mutation')
 })

--- a/server/graphql/rootQuery.js
+++ b/server/graphql/rootQuery.js
@@ -1,8 +1,9 @@
 import {GraphQLObjectType} from 'graphql'
+import {instrumentResolvers} from './util'
 
 import rootFields from './queries'
 
 export default new GraphQLObjectType({
   name: 'RootQuery',
-  fields: () => rootFields
+  fields: instrumentResolvers(rootFields, 'query')
 })


### PR DESCRIPTION
## Overview

All graphql requests look the same in newrelic:

![transactions_-_game_-_new_relic](https://cloud.githubusercontent.com/assets/189699/24760218/02657280-1ab6-11e7-8439-7d5fd1b63767.png)

So when we have performance issues it's hard to tell which requests are taking the most time. This PR changes the way transactions are named in newrelic so that they include the query or mutation name.

