### PR TITLE
pull coaches from users in state in UI instead of asking from query

### DIFF
--- a/common/actions/queries/findProjects.js
+++ b/common/actions/queries/findProjects.js
@@ -10,9 +10,7 @@ export default function findProjects(identifiers) {
           name
           playerIds
           createdAt
-          coach {
-            handle
-          }
+          coachId
           cycle {
             cycleNumber
           }

--- a/common/containers/ProjectList/index.jsx
+++ b/common/containers/ProjectList/index.jsx
@@ -76,13 +76,14 @@ function mapStateToProps(state) {
   const {projects: projectsById} = projects
   const {users: usersById} = users
 
-  const projectsWithMembers = Object.values(projectsById).map(project => {
+  const projectsWithUsers = Object.values(projectsById).map(project => {
+    const coach = usersById[project.coachId]
     const members = (project.playerIds || []).map(userId => (usersById[userId] || {}))
-    return {...project, members}
+    return {...project, members, coach}
   })
 
   // sort by cycle, title, name
-  const projectList = projectsWithMembers.sort((p1, p2) => {
+  const projectList = projectsWithUsers.sort((p1, p2) => {
     return (((p2.cycle || {}).cycleNumber || 0) - ((p1.cycle || {}).cycleNumber || 0)) ||
       (((p1.goal || {}).title || '').localeCompare((p2.goal || {}).title || '')) ||
       p1.name.localeCompare(p2.name)

--- a/server/graphql/schemas/Project.js
+++ b/server/graphql/schemas/Project.js
@@ -30,6 +30,7 @@ export default new GraphQLObjectType({
       expectedHours: {type: new GraphQLNonNull(GraphQLInt), description: 'Expected working hours in this project'},
       stats: {type: ProjectStats, description: 'The project stats', resolve: resolveProjectStats},
       playerIds: {type: new GraphQLList(GraphQLID), description: 'The project member UUIDs'},
+      coachId: {type: GraphQLID, description: "The project's coach's id"},
       coach: {type: UserProfile, description: 'The project coach', resolve: resolveProjectCoach},
       players: {type: new GraphQLList(UserProfile), description: 'The project members', resolve: resolveProjectPlayers},
       artifactURL: {type: GraphQLURL, description: 'The URL pointing to the output of this project'},


### PR DESCRIPTION
Fixes [ch1912](https://app.clubhouse.io/learnersguild/story/1912)
## Overview

The way we were asking for coaches was causing an n+1 query situation
where on the server we were spawning over 100 getUserById queries to
idm every time the project page loaded. Now we just get the ids from
game and pull the users out of the state.

## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

none

## Notes

none
