### PR TITLE
Pllearns/ch1596/eliminate project channels and replace project

### DIFF
--- a/common/models/__tests__/goal.test.js
+++ b/common/models/__tests__/goal.test.js
@@ -7,7 +7,6 @@ import {
   goalFromGoalLibraryMetadata,
   goalFromMetadata,
   renderGoalAsString,
-  renderGoalChannelName
 } from '../goal'
 
 /* eslint-disable camelcase */
@@ -90,15 +89,6 @@ describe(testContext(__filename), function () {
       const rendered = renderGoalAsString(goal)
       expect(rendered).to.contain(`#${goal.number}`)
       expect(rendered).to.contain(`${goal.title}`)
-    })
-  })
-
-  describe('renderGoalChannelName()', function () {
-    it('returns a goal name that is slugged and under 21 characters', function () {
-      const goal = {number: 144, level: 2, title: 'A random random goal title (kind of)'}
-      const rendered = renderGoalChannelName(goal)
-      const sluggedGoal = '144-a-random-random-go'
-      expect(rendered).to.contain(sluggedGoal)
     })
   })
 })

--- a/common/models/goal.js
+++ b/common/models/goal.js
@@ -1,5 +1,3 @@
-import {slugify} from '../util'
-
 const DEFAULT_TEAM_SIZE = 2
 
 /* eslint-disable camelcase */
@@ -66,9 +64,4 @@ export function goalFromGoalLibraryMetadata(goalMetadata) {
 export function renderGoalAsString(goal) {
   const goalLevel = goal.level ? ` [L${goal.level}]` : ''
   return `#${goal.number}${goalLevel}: ${goal.title}`
-}
-
-export function renderGoalChannelName(goal) {
-  const sluggedTitle = goal.number + '-' + slugify(goal.title)
-  return sluggedTitle.substring(0, 22)
 }

--- a/server/actions/__tests__/initializeProject.test.js
+++ b/server/actions/__tests__/initializeProject.test.js
@@ -3,8 +3,6 @@
 /* eslint-disable prefer-arrow-callback, no-unused-expressions, max-nested-callbacks */
 import {stub} from 'sinon'
 
-import {renderGoalChannelName} from 'src/common/models/goal'
-
 import stubs from 'src/test/stubs'
 import factory from 'src/test/factories'
 import {withDBCleanup, mockIdmUsersById} from 'src/test/helpers'
@@ -27,14 +25,12 @@ describe(testContext(__filename), function () {
     const initializeProject = require('../initializeProject')
 
     describe('when there is no goal channel', function () {
-      it('creates the project channel, goal channel, and welcome messages', async function () {
+      it('creates the goal channel, and sends welcome message', async function () {
         const memberHandles = this.users.map(u => u.handle)
         await initializeProject(this.project)
 
-        expect(chatService.createChannel).to.have.been.calledWith(this.project.name, [...memberHandles, 'echo'])
-        expect(chatService.createChannel).to.have.been.calledWith(renderGoalChannelName(this.project.goal), [...memberHandles, 'echo']) // eslint-disable-line camelcase
-        expect(chatService.sendChannelMessage).to.have.been.calledWithMatch(this.project.name, 'Welcome to the')
-        expect(chatService.sendChannelMessage).to.have.been.calledWithMatch(this.project.name, 'Your team is')
+        expect(chatService.createChannel).to.have.been.calledWith(String(this.project.goal.number), [...memberHandles, 'echo']) // eslint-disable-line camelcase
+        expect(chatService.sendMultiPartyDirectMessage).to.have.been.calledWithMatch([...memberHandles, 'echo'], 'Welcome to the')
       })
     })
 
@@ -48,15 +44,15 @@ describe(testContext(__filename), function () {
 
       it('adds the new project\'s members to the goal channel', async function () {
         await initializeProject(this.project)
+
         const secondTeamProject = await factory.create('project')
         secondTeamProject.goal = this.project.goal
 
-        const expectedChannelName = renderGoalChannelName(this.project.goal)
         const secondTeamUsers = await mockIdmUsersById(secondTeamProject.playerIds)
         const secondTeamHandles = secondTeamUsers.map(u => u.handle)
 
         await initializeProject(secondTeamProject)
-        expect(chatService.joinChannel).to.have.been.calledWith(expectedChannelName, [...secondTeamHandles, 'echo'])
+        expect(chatService.joinChannel).to.have.been.calledWith(String(secondTeamProject.goal.number), [...secondTeamHandles, 'echo'])
       })
     })
   })

--- a/server/actions/initializeProject.js
+++ b/server/actions/initializeProject.js
@@ -1,6 +1,4 @@
 import config from 'src/config'
-import {escapeMarkdownLinkTitle} from 'src/common/util'
-import {renderGoalChannelName} from 'src/common/models/goal'
 import getPlayerInfo from 'src/server/actions/getPlayerInfo'
 import {LGBadRequestError} from 'src/server/util/error'
 
@@ -19,50 +17,35 @@ export default async function initializeProject(project) {
 
 async function _initializeProjectChannel(project) {
   const chatService = require('src/server/services/chatService')
-  const {goal, name: channelName} = project
+  const {goal} = project
   const players = await getPlayerInfo(project.playerIds)
-  const goalLink = `[${goal.number}: ${escapeMarkdownLinkTitle(goal.title)}](${goal.url})`
+  const goalLink = `<${goal.url}|${goal.number}: ${goal.title}>`
   const channelUserNames = players.map(p => p.handle).concat(config.server.chat.userName)
 
-  try {
-    await chatService.createChannel(channelName, channelUserNames, goalLink)
-    // split welcome message into 2 so the goal link preview appears after the goal link
-    await chatService.sendChannelMessage(channelName, _welcomeMessage1(channelName, goalLink))
-    await chatService.sendChannelMessage(channelName, _welcomeMessage2(players))
-  } catch (err) {
-    if (_isDuplicateChannelError(err)) {
-      console.log(`Project channel ${channelName} already exists; initialization skipped`)
-    } else {
-      throw err
-    }
-  }
-  const goalChannelName = renderGoalChannelName(goal)
+  await chatService.sendMultiPartyDirectMessage(channelUserNames, _welcomeMessage(project, goalLink, players))
 
   try {
-    await chatService.createChannel(goalChannelName, channelUserNames, goalLink)
-    await chatService.sendChannelMessage(goalChannelName, _welcomeMessage1(goalChannelName, goalLink))
+    await chatService.createChannel(String(goal.number), channelUserNames, goalLink)
   } catch (err) {
     if (_isDuplicateChannelError(err)) {
-      await chatService.joinChannel(goalChannelName, channelUserNames)
+      await chatService.joinChannel(String(goal.number), channelUserNames)
     } else {
       throw err
     }
   }
 }
 
+// TODO -- figure out how Slack reports duplicate channels
 function _isDuplicateChannelError(error) {
   return (error.message || '').includes('error-duplicate-channel-name')
 }
 
-function _welcomeMessage1(channelName, goalLink) {
+function _welcomeMessage(project, goalLink, players) {
   return `
-🎊 *Welcome to the ${channelName} project channel!* 🎊
+🎊 *Welcome to the ${project.name} project!* 🎊
 
-*Your goal is:* ${goalLink}`
-}
+*Your goal is:* ${goalLink}
 
-function _welcomeMessage2(players) {
-  return `
 *Your team is:*
 ${players.map(p => `• _${p.name}_ - @${p.handle}`).join('\n  ')}
 

--- a/server/services/chatService/__tests__/createMultiPartyDirectMessage.test.js
+++ b/server/services/chatService/__tests__/createMultiPartyDirectMessage.test.js
@@ -1,0 +1,47 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+
+import nock from 'nock'
+
+import config from 'src/config'
+import stubs from 'src/test/stubs'
+import {useFixture} from 'src/test/helpers'
+
+describe(testContext(__filename), function () {
+  beforeEach(function () {
+    useFixture.nockClean()
+    this.apiScope = nock(config.server.chat.baseURL)
+    stubs.jobService.enable()
+  })
+  afterEach(function () {
+    stubs.jobService.disable()
+  })
+
+  describe('chatService', function () {
+    const {createMultiPartyDirectMessage} = require('../index')
+
+    describe('createMultiPartyDirectMessage()', function () {
+      beforeEach(function () {
+        this.apiScope
+          .post('/api/mpim.open')
+          .reply(200, {
+            ok: true,
+            group: {id: '12345'},
+            members: ['echo', 'pllearns'],
+          })
+          .post('/api/chat.postMessage')
+          .reply(200, {
+            ok: true,
+            channel: '12345',
+            text: 'Rubber Baby Buggy Bumpers',
+          })
+      })
+
+      it('returns the parsed response on success', function () {
+        const result = createMultiPartyDirectMessage(['echo', 'pllearns'], 'Rubber Baby Buggy Bumpers')
+        return expect(result).to.eventually.deep.equal(true)
+      })
+    })
+  })
+})

--- a/server/services/chatService/__tests__/index.test.js
+++ b/server/services/chatService/__tests__/index.test.js
@@ -31,6 +31,7 @@ describe(testContext(__filename), function () {
     const {
       sendChannelMessage,
       sendDirectMessage,
+      sendMultiPartyDirectMessage,
       sendResponseMessage,
     } = require('../index')
 
@@ -55,6 +56,19 @@ describe(testContext(__filename), function () {
         expect(jobService.createJob).to.have.been.calledWith('chatMessageSent', {
           type: 'user',
           target: userName,
+          msg: userMessage,
+        })
+      })
+    })
+
+    describe('sendMultiPartyDirectMessage()', function () {
+      it('queues the correct chat message job', async function () {
+        const userNames = ['supausah', 'supsuckah']
+        const userMessage = 'this is mah usah msg'
+        await sendMultiPartyDirectMessage(userNames, userMessage)
+        expect(jobService.createJob).to.have.been.calledWith('chatMessageSent', {
+          type: 'group',
+          target: userNames,
           msg: userMessage,
         })
       })

--- a/server/services/chatService/createMultiPartyDirectMessage.js
+++ b/server/services/chatService/createMultiPartyDirectMessage.js
@@ -1,0 +1,21 @@
+import {apiFetch} from './util'
+
+export default function createMultiPartyDirectMessage(users, msg) {
+  return apiFetch('/api/mpim.open', {
+    method: 'POST',
+    body: {
+      users: users.join(',')
+    }
+  })
+    .then(result => {
+      return apiFetch('/api/chat.postMessage', {
+        method: 'POST',
+        body: {
+          channel: result.group.id,
+          text: msg,
+          as_user: true, // eslint-disable-line camelcase
+        },
+      })
+    })
+    .then(result => result.ok)
+}

--- a/server/services/chatService/index.js
+++ b/server/services/chatService/index.js
@@ -3,6 +3,7 @@ import config from 'src/config'
 import {default as createChannel} from './createChannel'
 import {default as createChannelMessage} from './createChannelMessage'
 import {default as createDirectMessage} from './createDirectMessage'
+import {default as createMultiPartyDirectMessage} from './createMultiPartyDirectMessage'
 import {default as createResponseMessage} from './createResponseMessage'
 import {default as deleteChannel} from './deleteChannel'
 import {default as joinChannel} from './joinChannel'
@@ -17,6 +18,10 @@ function sendChannelMessage(channelName, message, options) {
 
 function sendDirectMessage(userName, message, options) {
   return _queueMessage('user', userName, message, options)
+}
+
+function sendMultiPartyDirectMessage(users, message, options) {
+  return _queueMessage('group', users, message, options)
 }
 
 function sendResponseMessage(responseURL, response, options) {
@@ -44,10 +49,12 @@ export default {
   createChannel,
   createChannelMessage,
   createDirectMessage,
+  createMultiPartyDirectMessage,
   createResponseMessage,
   deleteChannel,
   joinChannel,
   sendChannelMessage,
   sendDirectMessage,
+  sendMultiPartyDirectMessage,
   sendResponseMessage,
 }

--- a/server/workers/__tests__/projectArtifactChanged.test.js
+++ b/server/workers/__tests__/projectArtifactChanged.test.js
@@ -3,7 +3,7 @@
 /* eslint-disable prefer-arrow-callback, no-unused-expressions, max-nested-callbacks */
 import stubs from 'src/test/stubs'
 import factory from 'src/test/factories'
-import {withDBCleanup} from 'src/test/helpers'
+import {withDBCleanup, useFixture} from 'src/test/helpers'
 
 describe(testContext(__filename), function () {
   withDBCleanup()
@@ -21,20 +21,24 @@ describe(testContext(__filename), function () {
 
     describe('when a cycle has completed', function () {
       beforeEach(async function () {
+        this.users = await factory.buildMany('user', 4)
+        this.handles = this.users.map(user => user.handle)
         this.project = await factory.create('project', {
           artifactURL: 'https://example.com',
           name: 'curious-cats',
+          playerIds: this.users.map(user => user.id)
         })
+        useFixture.nockIDMGetUsersById(this.users)
       })
 
       it('sends a message to the chapter chatroom', async function () {
         await processProjectArtifactChanged(this.project)
 
-        expect(chatService.sendChannelMessage).to.have.been
-          .calledWithMatch(this.project.name, `[artifact](${this.project.artifactURL})`)
+        expect(chatService.sendMultiPartyDirectMessage).to.have.been
+          .calledWithMatch(this.handles, `[artifact](${this.project.artifactURL})`)
 
-        expect(chatService.sendChannelMessage).to.have.been
-          .calledWithMatch(this.project.name, `#${this.project.name} has been updated`)
+        expect(chatService.sendMultiPartyDirectMessage).to.have.been
+          .calledWithMatch(this.handles, `#${this.project.name} has been updated`)
       })
     })
   })

--- a/server/workers/__tests__/surveySubmitted.test.js
+++ b/server/workers/__tests__/surveySubmitted.test.js
@@ -36,6 +36,7 @@ describe(testContext(__filename), function () {
           projectState: PROJECT_STATES.IN_PROGRESS,
         })
         this.users = await mockIdmUsersById(this.project.playerIds, null, {times: 3})
+        this.handles = this.users.map(user => user.handle)
       })
       afterEach(function () {
         useFixture.nockClean()
@@ -61,9 +62,9 @@ describe(testContext(__filename), function () {
         })
 
         it('sends a message to the project chatroom', function () {
-          expect(chatService.sendChannelMessage.callCount).to.eq(1)
-          expect(chatService.sendChannelMessage).to.have.been.calledWithMatch(this.project.name, 'submitted their reflections')
-          expect(chatService.sendChannelMessage).to.have.been.calledWithMatch(this.project.name, 'completed')
+          expect(chatService.sendMultiPartyDirectMessage.callCount).to.eq(1)
+          expect(chatService.sendMultiPartyDirectMessage).to.have.been.calledWithMatch(this.handles, 'submitted their reflections')
+          expect(chatService.sendMultiPartyDirectMessage).to.have.been.calledWithMatch(this.handles, 'completed')
         })
 
         it('updates the project state', async function () {
@@ -76,7 +77,7 @@ describe(testContext(__filename), function () {
             respondentId: this.project.playerIds[0],
             survey: {id: this.survey.id},
           })
-          expect(chatService.sendChannelMessage.callCount).to.eq(2)
+          expect(chatService.sendMultiPartyDirectMessage.callCount).to.eq(2)
         })
       })
 
@@ -110,8 +111,11 @@ describe(testContext(__filename), function () {
     describe('for project review surveys', function () {
       useFixture.createProjectReviewSurvey()
 
-      beforeEach('setup test data', function () {
-        return this.createProjectReviewSurvey()
+      beforeEach('setup test data', async function () {
+        await this.createProjectReviewSurvey()
+        useFixture.nockClean()
+        this.users = await mockIdmUsersById(this.project.playerIds, null, {times: 4})
+        this.handles = this.users.map(user => user.handle)
       })
 
       describe('when the survey has been submitted', function () {
@@ -135,9 +139,9 @@ describe(testContext(__filename), function () {
             respondentId: this.project.playerIds[0],
             survey: {id: this.survey.id},
           })
-          expect(chatService.sendChannelMessage.callCount).to.eq(1)
-          expect(chatService.sendChannelMessage).to.have.been.calledWithMatch(this.project.name, 'project review has just been completed')
-          expect(chatService.sendChannelMessage).to.have.been.calledWithMatch(this.project.name, 'reviewed by 1 player')
+          expect(chatService.sendMultiPartyDirectMessage.callCount).to.eq(1)
+          expect(chatService.sendMultiPartyDirectMessage).to.have.been.calledWithMatch(this.handles, 'project review has just been completed')
+          expect(chatService.sendMultiPartyDirectMessage).to.have.been.calledWithMatch(this.handles, 'reviewed by 1 player')
         })
 
         it('updates the project stats', async function () {
@@ -157,8 +161,8 @@ describe(testContext(__filename), function () {
           }
           await processSurveySubmitted(event)
           await processSurveySubmitted(event)
-          expect(chatService.sendChannelMessage.callCount).to.eq(2)
-          expect(chatService.sendChannelMessage).to.have.been.calledWith(this.project.name)
+          expect(chatService.sendMultiPartyDirectMessage.callCount).to.eq(2)
+          expect(chatService.sendMultiPartyDirectMessage).to.have.been.calledWith(this.handles)
         })
       })
     })

--- a/server/workers/chatMessageSent.js
+++ b/server/workers/chatMessageSent.js
@@ -21,6 +21,9 @@ export async function processChatMessageSent({msg, target, type}) {
     case 'user':
       await Promise.each(msgs, msg => chatService.createDirectMessage(target, msg))
       break
+    case 'group':
+      await Promise.each(msgs, msg => chatService.createMultiPartyDirectMessage(target, msg))
+      break
     case 'response':
       await Promise.each(msgs, msg => chatService.createResponseMessage(target, msg))
       break

--- a/server/workers/projectArtifactChanged.js
+++ b/server/workers/projectArtifactChanged.js
@@ -1,3 +1,6 @@
+import {mapById} from 'src/common/util'
+import getPlayerInfo from 'src/server/actions/getPlayerInfo'
+
 export function start() {
   const jobService = require('src/server/services/jobService')
   jobService.processJobs('projectArtifactChanged', processProjectArtifactChanged)
@@ -7,7 +10,11 @@ export async function processProjectArtifactChanged(project) {
   const chatService = require('src/server/services/chatService')
 
   console.log(`Project artifact for project #${project.name} changed to ${project.artifactURL}`)
+  const projectUsersById = mapById(
+    await getPlayerInfo(project.playerIds)
+  )
+  const handles = project.playerIds.map(playerId => projectUsersById.get(playerId).handle)
 
   const announcement = `🔗 * The [artifact](${project.artifactURL}) for #${project.name} has been updated*.`
-  return chatService.sendChannelMessage(project.name, announcement)
+  return chatService.sendMultiPartyDirectMessage(handles, announcement)
 }

--- a/test/stubs/chatService.js
+++ b/test/stubs/chatService.js
@@ -13,6 +13,7 @@ export default {
     stub(chatService, 'sendChannelMessage', () => Promise.resolve({}))
     stub(chatService, 'sendDirectMessage', () => Promise.resolve({}))
     stub(chatService, 'sendResponseMessage', () => Promise.resolve({}))
+    stub(chatService, 'sendMultiPartyDirectMessage', () => Promise.resolve({}))
   },
 
   disable() {
@@ -25,5 +26,6 @@ export default {
     chatService.sendChannelMessage.restore()
     chatService.sendDirectMessage.restore()
     chatService.sendResponseMessage.restore()
+    chatService.sendMultiPartyDirectMessage.restore()
   },
 }


### PR DESCRIPTION
Fixes [ch1596](https://app.clubhouse.io/learnersguild/story/1596/eliminate-project-channels-and-replace-project-channel-messages-with-dms)

## Overview

We are doing away with project channels. As such, all calls to create a chat message in a project channel were replaced with a "multi-party DM". In addition, some of the messages have been reformatted to work with Slack (instead of Rocket.Chat).

## Data Model / DB Schema Changes

N/A

## Environment / Configuration Changes

N/A

## Notes

N/A