### PR TITLE
make sure not to use newrelic in dev

### DIFF
--- a/server/graphql/util/index.js
+++ b/server/graphql/util/index.js
@@ -1,5 +1,5 @@
 import {GraphQLError} from 'graphql/error'
-import newrelic from 'newrelic'
+import config from 'src/config'
 
 import {parseQueryError} from 'src/server/db/errors'
 
@@ -26,6 +26,11 @@ export function pruneAutoLoad(loadedModules) {
 }
 
 export function instrumentResolvers(fields, prefix) {
+  if (!config.server.newrelic.enabled) {
+    return fields
+  }
+  const newrelic = require('newrelic')
+
   return Object.entries(fields).map(([queryName, schema]) => {
     const originalResolver = schema.resolve
     return {


### PR DESCRIPTION
fixes these newreilc errors in dev:

```
New Relic for Node.js halted startup due to an error:
Error: Invalid license key, please contact support@newrelic.com
    at StreamSink.parser [as callback] (/Users/trevor/lg/game/node_modules/newrelic/lib/collector/parse-response.js:81:25)
    at StreamSink.end (/Users/trevor/lg/game/node_modules/newrelic/lib/util/stream-sink.js:43:8)
    at IncomingMessage.onend (_stream_readable.js:498:10)
    at IncomingMessage.g (events.js:273:16)
    at emitNone (events.js:85:20)
    at IncomingMessage.emit (events.js:179:7)
    at IncomingMessage.EventEmitter.emit (/Users/trevor/lg/game/node_modules/sc-domain/index.js:12:31)
    at endReadableNT (_stream_readable.js:913:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickDomainCallback [as _tickCallback] (internal/process/next_tick.js:122:9)
```