### PR TITLE
Single-player project Elo rating update fix #2

### DIFF
--- a/server/actions/savePlayerProjectStats.js
+++ b/server/actions/savePlayerProjectStats.js
@@ -23,12 +23,18 @@ export default async function savePlayerProjectStats(playerId, projectId, player
   const newPlayerStatsForProject = Object.assign({}, oldPlayerStatsForProject, playerStatsForProject)
   const newPlayerProjectStats = Object.assign({}, oldPlayerProjectStats, {[projectId]: newPlayerStatsForProject})
   const newPlayerStats = Object.assign({}, oldPlayerStats, {
-    [ELO]: Object.assign({}, playerStatsForProject[ELO] || {}), // non-cumulative; project-level stat becomes new overall stat
     [EXPERIENCE_POINTS]: _computeCumulativeStat(EXPERIENCE_POINTS, oldPlayerStats, oldPlayerStatsForProject, newPlayerStatsForProject),
     [RELATIVE_CONTRIBUTION_EFFECTIVE_CYCLES]: _computeCumulativeStat(RELATIVE_CONTRIBUTION_EFFECTIVE_CYCLES, oldPlayerStats, oldPlayerStatsForProject, newPlayerStatsForProject),
     projects: newPlayerProjectStats,
     weightedAverages: await _computePlayerStatsWeightedAverages(newPlayerProjectStats),
   })
+  if (playerStatsForProject[ELO]) {
+    // for Elo rating, project-level stat becomes new overall stat
+    newPlayerStats[ELO] = {
+      rating: playerStatsForProject[ELO].rating,
+      matches: playerStatsForProject[ELO].matches,
+    }
+  }
 
   // use updated top-level stats to determine new level
   const oldLevel = oldPlayerStats[LEVEL] || 0


### PR DESCRIPTION
Fixes [ch2209](https://app.clubhouse.io/learnersguild/story/2209).

Follow-up to https://github.com/LearnersGuild/game/pull/835.
- More careful/selective updating of Elo stat
- Even more single-player Elo & level tests