### PR TITLE
Chapter Form Fixes

### DIFF
--- a/common/actions/queries/saveChapter.js
+++ b/common/actions/queries/saveChapter.js
@@ -1,6 +1,6 @@
-export default function saveChapter(chapter) {
+export default function saveChapter({id, name, channelName, inviteCodes, timezone}) {
   return {
-    variables: {chapter},
+    variables: {chapter: {id, name, channelName, inviteCodes, timezone}},
     query: `
       mutation ($chapter: InputChapter!) {
         saveChapter(chapter: $chapter) {

--- a/common/components/ChapterForm/index.jsx
+++ b/common/components/ChapterForm/index.jsx
@@ -9,7 +9,7 @@ import Dropdown from 'react-toolbox/lib/dropdown'
 import InviteCodeForm from 'src/common/containers/InviteCodeForm'
 import ContentHeader from 'src/common/components/ContentHeader'
 import {Flex} from 'src/common/components/Layout'
-import {FORM_TYPES, renderInput} from 'src/common/util/form'
+import {renderInput} from 'src/common/util/form'
 import {slugify} from 'src/common/util'
 
 import styles from './index.scss'
@@ -85,7 +85,7 @@ class ChapterForm extends Component {
       handleSubmit,
       submitting,
       onSaveChapter,
-      formType,
+      title,
       inviteCodes,
       showCreateInviteCode,
       invalid,
@@ -93,13 +93,12 @@ class ChapterForm extends Component {
       formValues,
     } = this.props
 
-    const canManageInviteCodes = showCreateInviteCode &&
-      formType === FORM_TYPES.UPDATE &&
-      Boolean(formValues.id)
-
+    let inviteCodeDialog
     let inviteCodeField
     let createInviteCodeButton
-    if (canManageInviteCodes) {
+    if (showCreateInviteCode && Boolean(formValues.id)) {
+      inviteCodeDialog = this.renderInviteCodeDialog()
+
       inviteCodeField = (
         <Input
           type="text"
@@ -123,10 +122,6 @@ class ChapterForm extends Component {
           />
       )
     }
-
-    const title = formType === FORM_TYPES.CREATE ?
-      'Create Chapter' :
-      `Edit Chapter: ${formValues.name}`
 
     return (
       <div>
@@ -171,20 +166,20 @@ class ChapterForm extends Component {
               />
           </Flex>
         </form>
-        {canManageInviteCodes ? this.renderInviteCodeDialog() : null}
+        {inviteCodeDialog}
       </div>
     )
   }
 }
 
 ChapterForm.propTypes = {
+  title: PropTypes.string,
   formValues: PropTypes.object.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   change: PropTypes.func.isRequired,
   invalid: PropTypes.bool.isRequired,
   submitting: PropTypes.bool.isRequired,
   pristine: PropTypes.bool.isRequired,
-  formType: PropTypes.oneOf(Object.values(FORM_TYPES)).isRequired,
   inviteCodes: PropTypes.array.isRequired,
   showCreateInviteCode: PropTypes.bool.isRequired,
   onSaveChapter: PropTypes.func.isRequired,

--- a/common/components/__tests__/ChapterForm.test.js
+++ b/common/components/__tests__/ChapterForm.test.js
@@ -56,7 +56,6 @@ describe(testContext(__filename), function () {
         handleSubmit: () => null,
         submitting: false,
         submitFailed: false,
-        formType: 'update',
         showCreateInviteCode: false,
         onSaveInviteCode: () => null,
         onSaveChapter: () => null,


### PR DESCRIPTION
Fixes [ch2238](https://app.clubhouse.io/learnersguild/story/2238).
Fixes [ch2184](https://app.clubhouse.io/learnersguild/story/2184).

## Overview

Minor chapter form bug fixes:
- [ch2238] now that chapters can be retrieved by name or ID, it isn't guaranteed that the ID of the chapter is known/available when the form is first rendered. this is especially important because of how the invite code form was being rendered; the required chapter ID was missing from the hidden field as a re-render wasn't being triggered even after the chapter was loaded and the ID value was known (possibly a `redux-form` issue since the ID is pulled out of the `formValues` prop).
- [ch2184] the chapter obj retrieved for pre-filling form values doesn't have the same schema as that which is accepted as input for chapter updates. picks only valid fields for the input schema when saving.

Other:
- no longer uses the unnecessary `FORM_TYPE` constants for create vs. update rendering logic

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.

