### PR TITLE
throws an error in /cycle init if expected hours aren't specified

### DIFF
--- a/server/cliCommand/commands/__tests__/cycle.test.js
+++ b/server/cliCommand/commands/__tests__/cycle.test.js
@@ -22,15 +22,16 @@ describe(testContext(__filename), function () {
   })
 
   describe('cycle init', function () {
-    it('returns an "Initializing" message on success', async function () {
+    it('throws an LGBadRequestError if expected hours are not given', async function () {
       const args = this.commandSpec.parse(['init'])
-      const result = await this.commandImpl.invoke(args, {user: this.moderatorUser})
-      expect(concatResults(result)).to.match(/Initializing/i)
+      const result = this.commandImpl.invoke(args, {user: this.moderatorUser})
+      expect(result).to.be.rejectedWith(/You must specify expected hours for the new cycle./)
     })
 
-    it('reports the default project hours when requested', async function () {
+    it('returns an Initializing message on success and reports the default hours', async function () {
       const args = this.commandSpec.parse(['init', '--hours=32'])
       const result = await this.commandImpl.invoke(args, {user: this.moderatorUser})
+      expect(concatResults(result)).to.match(/Initializing/i)
       expect(concatResults(result)).to.match(/32/)
     })
   })

--- a/server/cliCommand/commands/cycle.js
+++ b/server/cliCommand/commands/cycle.js
@@ -13,15 +13,17 @@ import {
 
 const subcommands = {
   async init(args, {user}) {
+    if (!args.hours) {
+      throw new LGBadRequestError('You must specify expected hours for the new cycle.')
+    }
+
     await _createCycle(user, args.hours)
 
-    const attachments = []
-    if (args.hours) {
-      attachments.push({text: `Expected hours per project: ${args.hours}`})
-    }
     return {
       text: '🔃  Initializing Cycle ... stand by.',
-      attachments,
+      attachments: [
+        {text: `Expected hours per project: ${args.hours}`}
+      ],
     }
   },
 


### PR DESCRIPTION
Fixes [ch1760](https://app.clubhouse.io/learnersguild/story/1760)

## Overview
* Just added an error case to the check for `args.hours` so far.
