### PR TITLE
adds responseURL to Vote model

### DIFF
--- a/server/services/dataService/models/vote.js
+++ b/server/services/dataService/models/vote.js
@@ -27,6 +27,10 @@ export default function voteModel(thinky) {
         .allowNull(true)
         .default(null),
 
+      responseURL: string()
+        .allowNull(true)
+        .default(null),
+
       createdAt: date()
         .allowNull(false)
         .default(r.now()),


### PR DESCRIPTION
Fixes [ch2314](https://app.clubhouse.io/learnersguild/story/2314)

## Overview
* The responseURL for slack commands was previously undefined because it wasn't included in the model.
