### PR TITLE
return 200s for users errors so they propagate back to the user

### DIFF
--- a/server/cliCommand/index.js
+++ b/server/cliCommand/index.js
@@ -74,11 +74,16 @@ app.use('/command', (err, req, res, next) => { // eslint-disable-line no-unused-
     }],
     /* eslint-enable camelcase */
   }
-  const {statusCode = 500} = formattedErr
+  let {statusCode = 500} = formattedErr
   if (statusCode >= 500) {
     console.error(formattedErr.stack || formattedErr)
     sentry.captureException(formattedErr)
+  } else {
+    // For what would normally be 400 errors or any non fatal errors
+    // use a 200 status code to comply with the Slack API
+    statusCode = 200
   }
+
   res.status(statusCode).json(result)
 })
 


### PR DESCRIPTION
Fixes [ch2316](https://app.clubhouse.io/learnersguild/story/2316)

## Overview

The Slack API requires that we return success codes if we want to display info to the user. So for any non 500 errors we're setting the status code to 200.

## Data Model / DB Schema Changes

nope

## Environment / Configuration Changes

nope

## Notes

nope
