### PR TITLE
adding load more functionality

### DIFF
--- a/common/actions/project.js
+++ b/common/actions/project.js
@@ -9,11 +9,11 @@ export function findMyProjects() {
   return _findProjects('findMyProjects')
 }
 
-export function findProjects(identifiers) {
-  return _findProjects('findProjects', identifiers)
+export function findProjects(options) {
+  return _findProjects('findProjects', options)
 }
 
-function _findProjects(queryName, variables) {
+function _findProjects(queryName, options) {
   return {
     types: [
       types.FIND_PROJECTS_REQUEST,
@@ -22,7 +22,7 @@ function _findProjects(queryName, variables) {
     ],
     shouldCallAPI: () => true,
     callAPI: (dispatch, getState) => {
-      const query = queries[queryName](variables)
+      const query = queries[queryName](options)
       return getGraphQLFetcher(dispatch, getState().auth)(query)
         .then(graphQLResponse => graphQLResponse.data[queryName])
         .then(projects => normalize(projects, schemas.projects))

--- a/common/actions/queries/findMyProjects.js
+++ b/common/actions/queries/findMyProjects.js
@@ -11,6 +11,7 @@ export default function findMyProjects(identifiers) {
           playerIds
           createdAt
           cycle {
+            id
             cycleNumber
           }
           goal {

--- a/common/actions/queries/findProjects.js
+++ b/common/actions/queries/findProjects.js
@@ -1,11 +1,11 @@
 import {STAT_DESCRIPTORS} from 'src/common/models/stat'
 
-export default function findProjects(identifiers) {
+export default function findProjects({page, identifiers} = {}) {
   return {
-    variables: {identifiers},
+    variables: {page, identifiers},
     query: `
-      query ($identifiers: [String]) {
-        findProjects(identifiers: $identifiers) {
+      query ($identifiers: [String], $page: ProjectPageInput) {
+        findProjects(identifiers: $identifiers, page: $page) {
           id
           name
           state
@@ -13,6 +13,7 @@ export default function findProjects(identifiers) {
           createdAt
           coachId
           cycle {
+            id
             cycleNumber
             state
           }

--- a/common/components/ProjectList/index.jsx
+++ b/common/components/ProjectList/index.jsx
@@ -1,4 +1,5 @@
 import React, {Component, PropTypes} from 'react'
+import {Button} from 'react-toolbox/lib/button'
 
 import ContentHeader from 'src/common/components/ContentHeader'
 import ContentTable from 'src/common/components/ContentTable'
@@ -58,6 +59,7 @@ export default class ProjectList extends Component {
       <Flex column>
         {header}
         {content}
+        <Button onClick={this.props.onLoadMoreClicked} label="Load More..." icon="keyboard_arrow_down" accent/>
       </Flex>
     )
   }
@@ -86,4 +88,5 @@ ProjectList.propTypes = {
   allowImport: PropTypes.bool,
   onSelectRow: PropTypes.func,
   onClickImport: PropTypes.func,
+  onLoadMoreClicked: PropTypes.func,
 }

--- a/common/containers/ProjectList/index.jsx
+++ b/common/containers/ProjectList/index.jsx
@@ -43,6 +43,7 @@ class ProjectListContainer extends Component {
         allowImport={userCan(currentUser, 'importProject')}
         onSelectRow={this.handleSelectRow}
         onClickImport={this.handleClickImport}
+        onLoadMoreClicked={this.props.handleLoadMore}
         />
     )
   }
@@ -50,10 +51,12 @@ class ProjectListContainer extends Component {
 
 ProjectListContainer.propTypes = {
   projects: PropTypes.array.isRequired,
+  oldestCycleLoadedId: PropTypes.string,
   isBusy: PropTypes.bool.isRequired,
   loading: PropTypes.bool.isRequired,
   currentUser: PropTypes.object.isRequired,
   fetchData: PropTypes.func.isRequired,
+  handleLoadMore: PropTypes.func.isRequired,
   navigate: PropTypes.func.isRequired,
   showLoad: PropTypes.func.isRequired,
   hideLoad: PropTypes.func.isRequired,
@@ -89,10 +92,14 @@ function mapStateToProps(state) {
       p1.name.localeCompare(p2.name)
   })
 
+  const oldestCycleLoadedId =
+    projectList.length > 0 ? projectList[projectList.length - 1].cycle.id : null
+
   return {
     isBusy: projects.isBusy || users.isBusy,
     loading: app.showLoading,
     currentUser: auth.currentUser,
+    oldestCycleLoadedId,
     projects: projectList,
   }
 }
@@ -102,6 +109,12 @@ function mapDispatchToProps(dispatch) {
     navigate: path => dispatch(push(path)),
     showLoad: () => dispatch(showLoad()),
     hideLoad: () => dispatch(hideLoad()),
+    handleLoadMore: props => {
+      return () => dispatch(findProjects({page: {
+        cycleId: props.oldestCycleLoadedId,
+        direction: 'prev',
+      }}))
+    },
     fetchData: props => {
       return () => fetchData(dispatch, props)
     },
@@ -114,6 +127,7 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
     ...dispatchProps,
     ...stateAndOwnProps,
     fetchData: dispatchProps.fetchData(stateAndOwnProps),
+    handleLoadMore: dispatchProps.handleLoadMore(stateAndOwnProps),
   }
 }
 

--- a/server/actions/getNextCycleIfExists.js
+++ b/server/actions/getNextCycleIfExists.js
@@ -1,0 +1,9 @@
+import {r, errors, Cycle} from 'src/server/services/dataService'
+
+export default function getNextCycleIfExists(cycle) {
+  return Cycle
+    .filter(_ => _('createdAt').gt(cycle.createdAt))
+    .orderBy(r.asc('createdAt'))
+    .nth(0)
+    .catch(errors.DocumentNotFound, _ => null)
+}

--- a/server/actions/getPrevCycleIfExists.js
+++ b/server/actions/getPrevCycleIfExists.js
@@ -1,0 +1,9 @@
+import {r, errors, Cycle} from 'src/server/services/dataService'
+
+export default function getPrevCycleIfExists(cycle) {
+  return Cycle
+    .filter(_ => _('createdAt').lt(cycle.createdAt))
+    .orderBy(r.desc('createdAt'))
+    .nth(0)
+    .catch(errors.DocumentNotFound, _ => null)
+}

--- a/server/graphql/queries/findProjects.js
+++ b/server/graphql/queries/findProjects.js
@@ -1,20 +1,37 @@
-import {GraphQLString} from 'graphql'
-import {GraphQLList} from 'graphql/type'
+import {GraphQLString, GraphQLID} from 'graphql'
+import {GraphQLList, GraphQLInputObjectType} from 'graphql/type'
 
-import {userCan} from 'src/common/util'
-import {findProjects} from 'src/server/services/dataService'
 import {Project} from 'src/server/graphql/schemas'
+import {userCan} from 'src/common/util'
 import {LGNotAuthorizedError} from 'src/server/util/error'
+import {resolveFindProjects} from 'src/server/graphql/resolvers'
 
 export default {
   type: new GraphQLList(Project),
   args: {
     identifiers: {type: new GraphQLList(GraphQLString), description: 'A list of project identifiers'},
+    page: {
+      type: new GraphQLInputObjectType({
+        name: 'ProjectPageInput',
+        description: 'The details about which page of project results to return',
+        fields: () => ({
+          cycleId: {
+            type: GraphQLID,
+            description: 'The name of the question in the survey'
+          },
+          direction: {
+            type: GraphQLString,
+            description: 'The direction to go for the next page'
+          },
+        })
+      }),
+      description: 'Parameters For requesting certain pages'
+    },
   },
   async resolve(source, args = {}, {rootValue: {currentUser}}) {
     if (!userCan(currentUser, 'findProjects')) {
       throw new LGNotAuthorizedError()
     }
-    return findProjects(args.identifiers)
+    return resolveFindProjects(args, currentUser)
   },
 }

--- a/server/graphql/queries/getProjectSummaryForPlayer.js
+++ b/server/graphql/queries/getProjectSummaryForPlayer.js
@@ -1,8 +1,8 @@
 import {
   getLatestCycleForChapter,
   getUserById,
-  findProjects,
   findProjectsForUser,
+  Project,
 } from 'src/server/services/dataService'
 import {ProjectsSummary} from 'src/server/graphql/schemas'
 import {LGNotAuthorizedError} from 'src/server/util/error'
@@ -17,7 +17,7 @@ export default {
     const user = await getUserById(currentUser.id, {mergeChapter: true})
     const cycle = await getLatestCycleForChapter(user.chapter.id)
 
-    const numActiveProjectsForCycle = await findProjects({chapterId: user.chapter.id, cycleId: cycle.id}).count()
+    const numActiveProjectsForCycle = await Project.filter({chapterId: user.chapter.id, cycleId: cycle.id}).count()
     const numTotalProjectsForPlayer = await findProjectsForUser(user.id).count()
 
     return {numActiveProjectsForCycle, numTotalProjectsForPlayer}

--- a/server/workers/cycleReflectionStarted.js
+++ b/server/workers/cycleReflectionStarted.js
@@ -2,7 +2,7 @@ import Promise from 'bluebird'
 
 import {mapById} from 'src/common/util'
 import getPlayerInfo from 'src/server/actions/getPlayerInfo'
-import {Chapter, Moderator, findProjects} from 'src/server/services/dataService'
+import {Chapter, Moderator, Project} from 'src/server/services/dataService'
 import ensureCycleReflectionSurveysExist from 'src/server/actions/ensureCycleReflectionSurveysExist'
 import reloadSurveyAndQuestionData from 'src/server/actions/reloadSurveyAndQuestionData'
 
@@ -48,7 +48,7 @@ async function _notifyModerators(chapterId, message) {
 
 async function _createReflectionAnnoucements(chapter, cycle, message) {
   const chatService = require('src/server/services/chatService')
-  const projects = await findProjects({chapterId: cycle.chapterId, cycleId: cycle.id})
+  const projects = await Project.filter({chapterId: cycle.chapterId, cycleId: cycle.id})
 
   // get all user info from IDM in one fell swoop
   const allPlayerIds = projects.reduce((result, project) => {


### PR DESCRIPTION
Fixes [ch1850](https://app.clubhouse.io/learnersguild/story/1850)

## Overview

Adding "load more" button to load just a cycle of projects at a time on the projects page. This should ease the performance issues we've been having. We still need to make the query smarter.

## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

none

## Notes

I originally started implementing the "next page", "previous page" solution outlined in the ticket but ran into some issues with that. It turns out even when paging by cycle it gets more complicated and you still have to contend with the typical "how do I know if there's another page" cycle issue. Instead of opting for the "real" generic pagination solution I decided to go in the other direction and use an even simpler implementation that avoids some of the complexity of the solution outlined in the story.

We will eventually need to do _real_ pagination and searching on this page.

Also, we will eventually need to make the graphql resolvers more efficient.
