### PR TITLE
Send messages every 24 hours if project artifact is not set.

### DIFF
--- a/server/actions/__tests__/ensureProjectArtifactIsSet.test.js
+++ b/server/actions/__tests__/ensureProjectArtifactIsSet.test.js
@@ -1,0 +1,41 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions, max-nested-callbacks */
+import stubs from 'src/test/stubs'
+import factory from 'src/test/factories'
+import {withDBCleanup, mockIdmUsersById, useFixture} from 'src/test/helpers'
+
+describe(testContext(__filename), function () {
+  withDBCleanup()
+  beforeEach(function () {
+    stubs.chatService.enable()
+  })
+  afterEach(function () {
+    stubs.chatService.disable()
+  })
+
+  beforeEach('setup data & mocks', async function () {
+    useFixture.nockClean()
+    this.project = await factory.build('project')
+    this.users = await mockIdmUsersById(this.project.playerIds)
+  })
+
+  const chatService = require('src/server/services/chatService')
+  const ensureProjectArtifactIsSet = require('../ensureProjectArtifactIsSet')
+
+  it('send a team DM when there is no artificat set', async function () {
+    this.project.artifactURL = null
+    await ensureProjectArtifactIsSet(this.project)
+
+    const userHandles = this.users.map(_ => _.handle)
+    expect(chatService.sendDirectMessage).to.have.been.calledWithMatch(
+      userHandles,
+      /set your artifact/
+    )
+  })
+
+  it('does nothing when there is and artificat set', async function () {
+    await ensureProjectArtifactIsSet(this.project)
+    expect(chatService.sendDirectMessage).to.not.have.been.called
+  })
+})

--- a/server/actions/ensureProjectArtifactIsSet.js
+++ b/server/actions/ensureProjectArtifactIsSet.js
@@ -1,0 +1,19 @@
+import getPlayerInfo from 'src/server/actions/getPlayerInfo'
+
+export default async function ensureProjectArtifactIsSet(project) {
+  const chatService = require('src/server/services/chatService')
+
+  if (project.artifactURL) {
+    return true
+  }
+
+  const playerInfo = await getPlayerInfo(project.playerIds)
+  const playerHandles = playerInfo.map(_ => _.handle)
+
+  const message = `⏰ *Your project artifact for \`${project.name}\` is still not set.* \n` +
+    "> Please stop what you're doing and use the `/project set-artifact` command to set your artifact."
+
+  await chatService.sendDirectMessage(playerHandles, message)
+
+  return false
+}

--- a/server/configureChangeFeeds/index.js
+++ b/server/configureChangeFeeds/index.js
@@ -1,5 +1,5 @@
 import {GOAL_SELECTION, PRACTICE, REFLECTION, COMPLETE} from 'src/common/models/cycle'
-import {REVIEW} from 'src/common/models/project'
+import {IN_PROGRESS, REVIEW} from 'src/common/models/project'
 
 import chapterCreated from './chapterCreated'
 import cycleStateChanged from './cycleStateChanged'
@@ -20,6 +20,7 @@ export default function configureChangeFeeds() {
       [COMPLETE]: queueService.getQueue('cycleCompleted'),
     })
     projectStateChanged({
+      [IN_PROGRESS]: queueService.getQueue('projectStarted'),
       [REVIEW]: queueService.getQueue('projectReviewStarted'),
     })
     projectArtifactChanged(queueService.getQueue('projectArtifactChanged'))

--- a/server/workers/index.js
+++ b/server/workers/index.js
@@ -12,6 +12,8 @@ require('./surveySubmitted').start()
 require('./userCreated').start()
 require('./voteSubmitted').start()
 require('./projectFormationComplete').start()
+require('./projectStarted').start()
+require('./projectArtifactDeadlinePassed').start()
 
 // start change feed listeners
 require('src/server/configureChangeFeeds')()

--- a/server/workers/projectArtifactDeadlinePassed.js
+++ b/server/workers/projectArtifactDeadlinePassed.js
@@ -1,0 +1,19 @@
+import {Project} from 'src/server/services/dataService'
+import ensureProjectArtifactIsSet from 'src/server/actions/ensureProjectArtifactIsSet'
+
+const TWENTY_FOUR_HOURS_IN_MS = 1000 * 60 * 60 * 24
+
+export function start() {
+  const jobService = require('src/server/services/jobService')
+  jobService.processJobs('projectArtifactDeadlinePassed', processProjectArtifactDeadlinePassed)
+}
+
+export async function processProjectArtifactDeadlinePassed(projectId) {
+  const project = await Project.get(projectId)
+  const artifactIsSet = await ensureProjectArtifactIsSet(project)
+
+  if (!artifactIsSet) {
+    const jobService = require('src/server/services/jobService')
+    jobService.createJob('projectArtifactDeadlinePassed', projectId, {delay: TWENTY_FOUR_HOURS_IN_MS})
+  }
+}

--- a/server/workers/projectStarted.js
+++ b/server/workers/projectStarted.js
@@ -1,0 +1,11 @@
+const TWENTY_FOUR_HOURS_IN_MS = 1000 * 60 * 60 * 24
+
+export function start() {
+  const jobService = require('src/server/services/jobService')
+  jobService.processJobs('projectStarted', processProjectStarted)
+}
+
+export function processProjectStarted(project) {
+  const jobService = require('src/server/services/jobService')
+  jobService.createJob('projectArtifactDeadlinePassed', project.id, {delay: TWENTY_FOUR_HOURS_IN_MS})
+}


### PR DESCRIPTION
Fixes [ch2333](https://app.clubhouse.io/learnersguild/story/2333)

## Overview

<img width="751" alt="slack_-_learnersguild-dev" src="https://cloud.githubusercontent.com/assets/189699/25752566/afa52454-3186-11e7-80d6-634e97d4f08f.png">

We're adding adding a `projectStarted` event which will be triggered by
the existing changefeed listener on project states.

The `projectStarted` worker will in turn created a
`projectArtifactDeadlinePassed` event with a delay of 24 hours.

The `projectArtifactDeadlinePassed` worker will check for the presence of
an `artifactURL` in the project and then, if it doesn't exist, send the
team a group DM and then queue another `projectArtifactDeadlinePassed` job
for 24 later.

## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

Adds a couple new workers.

## Notes

none
