### PR TITLE
don't calculate a level (v2) is there's no XP (v2) for a project yet

### DIFF
--- a/server/actions/__tests__/savePlayerProjectStats.test.js
+++ b/server/actions/__tests__/savePlayerProjectStats.test.js
@@ -14,7 +14,6 @@ import savePlayerProjectStats from '../savePlayerProjectStats'
 const {
   CULTURE_CONTRIBUTION,
   LEVEL,
-  LEVEL_V2,
   PROJECT_HOURS,
   RELATIVE_CONTRIBUTION,
   RELATIVE_CONTRIBUTION_AGGREGATE_CYCLES,
@@ -47,7 +46,7 @@ describe(testContext(__filename), function () {
       [TEAM_PLAY]: 83,
       [TECHNICAL_HEALTH]: 80,
     }
-    const expectedSavedProjectStats = {...projectStats, [LEVEL]: {starting: 0, ending: 0}, [LEVEL_V2]: {starting: 0, ending: 0}}
+    const expectedSavedProjectStats = {...projectStats, [LEVEL]: {starting: 0, ending: 0}}
     await Player.get(this.player.id).update({stats: null})
     await savePlayerProjectStats(this.player.id, this.projectIds[0], projectStats)
 
@@ -73,7 +72,7 @@ describe(testContext(__filename), function () {
       [TEAM_PLAY]: 83,
       [TECHNICAL_HEALTH]: 80,
     }
-    const expectedSavedProjectStats = {...projectStats, [LEVEL]: {starting: 0, ending: 0}, [LEVEL_V2]: {starting: 0, ending: 0}}
+    const expectedSavedProjectStats = {...projectStats, [LEVEL]: {starting: 0, ending: 0}}
     await Player.get(this.player.id).update({stats: {[RELATIVE_CONTRIBUTION_EFFECTIVE_CYCLES]: 10}})
     await savePlayerProjectStats(this.player.id, this.projectIds[1], projectStats)
 
@@ -99,7 +98,7 @@ describe(testContext(__filename), function () {
       [TEAM_PLAY]: 83,
       [TECHNICAL_HEALTH]: 80,
     }
-    const expectedSavedProjectStats = {...projectStats, [LEVEL]: {starting: 0, ending: 0}, [LEVEL_V2]: {starting: 0, ending: 0}}
+    const expectedSavedProjectStats = {...projectStats, [LEVEL]: {starting: 0, ending: 0}}
     await savePlayerProjectStats(this.player.id, this.projectIds[0], projectStats)
 
     const player = await Player.get(this.player.id)
@@ -137,7 +136,6 @@ describe(testContext(__filename), function () {
     const expectedSavedProjectsStats = projectsStats.map(projectStats => ({
       ...projectStats,
       [LEVEL]: {starting: 0, ending: 0},
-      [LEVEL_V2]: {starting: 0, ending: 0},
     }))
     await savePlayerProjectStats(this.player.id, this.projectIds[0], expectedSavedProjectsStats[0])
     await savePlayerProjectStats(this.player.id, this.projectIds[1], expectedSavedProjectsStats[1])
@@ -186,7 +184,7 @@ describe(testContext(__filename), function () {
       [TEAM_PLAY]: 40,
       [TECHNICAL_HEALTH]: 90,
     }
-    const expectedSavedProjectStats2 = {...projectStats2, [LEVEL]: {starting: 0, ending: 0}, [LEVEL_V2]: {starting: 0, ending: 0}}
+    const expectedSavedProjectStats2 = {...projectStats2, [LEVEL]: {starting: 0, ending: 0}}
     await savePlayerProjectStats(this.player.id, this.projectIds[1], projectStats2)
     expect(await Player.get(this.player.id)).to.have.deep.property(`stats.${RELATIVE_CONTRIBUTION_EFFECTIVE_CYCLES}`, 30)
     expect(await Player.get(this.player.id)).to.have.deep.property(`stats.projects.${this.projectIds[1]}`).deep.eq(expectedSavedProjectStats2)
@@ -203,7 +201,7 @@ describe(testContext(__filename), function () {
       [TEAM_PLAY]: 65,
       [TECHNICAL_HEALTH]: 95,
     }
-    const expectedSavedProjectStats3 = {...projectStats3, [LEVEL]: {starting: 0, ending: 0}, [LEVEL_V2]: {starting: 0, ending: 0}}
+    const expectedSavedProjectStats3 = {...projectStats3, [LEVEL]: {starting: 0, ending: 0}}
     await savePlayerProjectStats(this.player.id, this.projectIds[1], projectStats3)
     expect(await Player.get(this.player.id)).to.have.deep.property(`stats.${RELATIVE_CONTRIBUTION_EFFECTIVE_CYCLES}`, 20)
     expect(await Player.get(this.player.id)).to.have.deep.property(`stats.projects.${this.projectIds[1]}`).deep.eq(expectedSavedProjectStats3)

--- a/server/actions/savePlayerProjectStats.js
+++ b/server/actions/savePlayerProjectStats.js
@@ -49,7 +49,7 @@ export default async function savePlayerProjectStats(playerId, projectId, player
     const oldLevelV2 = oldPlayerStats[LEVEL_V2] || 0
     const newLevelV2 = await computePlayerLevelV2(newPlayerStats)
     newPlayerStats[LEVEL_V2] = newLevelV2
-    newPlayerStats.projects[projectId][LEVEL_V2] = {starting: oldLevelV2, ending: newLevelV2}
+    newPlayerStatsForProject[LEVEL_V2] = {starting: oldLevelV2, ending: newLevelV2}
   }
 
   return Player.get(playerId).updateWithTimestamp({


### PR DESCRIPTION
Fixes [ch2383](https://app.clubhouse.io/learnersguild/story/2383)

## Overview

We're calculating level V2 before we have XP V2 (after the retro's are completed for a project but it's still in review. So with 0 XPV2 we end up assigning a level of "0" to the player for that project (and averaging it into their XP Pace I think), which looks wrong (and scary 😱) in the UI.

## Notes

*We need to rerun `npm run stats` in prod to fix the data.*