### PR TITLE
Project Summary shows user level changes

### DIFF
--- a/common/components/ProjectUserSummary/index.jsx
+++ b/common/components/ProjectUserSummary/index.jsx
@@ -73,6 +73,17 @@ export default class ProjectUserSummary extends Component {
       return Number.isFinite(starting) ? starting : BLANK
     }
 
+    const displayEndingLevel = statName => {
+      const ending = (userProjectStats[statName] || {}).ending
+      return Number.isFinite(ending) ? ending : BLANK
+    }
+
+    const displayLevelProgress = statName => {
+      const starting = displayStartingLevel(statName)
+      const ending = displayEndingLevel(statName)
+      return starting === ending ? starting : `${starting} → ${ending}`
+    }
+
     const userProfilePath = `/users/${user.handle}`
     const renderStat = getStatRenderer(userProjectStats)
 
@@ -92,8 +103,8 @@ export default class ProjectUserSummary extends Component {
             </div>
             <div>{user.name}</div>
             <div>{renderStat(STAT_DESCRIPTORS.RELATIVE_CONTRIBUTION, '%')} {'Effective Contribution'}</div>
-            <div>Level {displayStartingLevel(STAT_DESCRIPTORS.LEVEL)}</div>
-            <div className={styles.betaStat}>Level.v2 {displayStartingLevel(STAT_DESCRIPTORS.LEVEL_V2)}</div>
+            <div>Level {displayLevelProgress(STAT_DESCRIPTORS.LEVEL)}</div>
+            <div className={styles.betaStat}>Level.v2 {displayLevelProgress(STAT_DESCRIPTORS.LEVEL_V2)}</div>
             <div>{renderStat(STAT_DESCRIPTORS.PROJECT_HOURS)} hours [team total: {roundDecimal(totalProjectHours)}]</div>
             {this.renderSurveyLockUnlock()}
           </div>


### PR DESCRIPTION
Fixes [ch2468](https://app.clubhouse.io/learnersguild/story/2468)

## Overview

User Level bug on Project Summary page was due to the ProjectUserSummary component only showing a user's starting level for that project.  We updated the component to show the transition from starting level to ending level, as it does on the User Details page.

## Data Model / DB Schema Changes

nome

## Environment / Configuration Changes

none

## Notes

none
