### PR TITLE
Adds message and error to saveReview triggered when project has no coach

### DIFF
--- a/server/cliCommand/commands/__tests__/review.test.js
+++ b/server/cliCommand/commands/__tests__/review.test.js
@@ -122,6 +122,21 @@ describe(testContext(__filename), function () {
         expect(chatService.sendDirectMessage).to.have.been.calledWith(playerHandles, `A review has been blocked for project ${this.project.name}. Please set your artifact.`)
       })
     })
+
+    describe('attempting to submit a review when no lead coach is assigned', function () {
+      const chatService = require('src/server/services/chatService')
+      it('throws an error and direct messages the project members', async function () {
+        await Project.get(this.project.id).update({coachId: null})
+
+        const responses = [{questionsName: 'completeness', responseParams: ['80']}]
+        const playerHandles = this.players.map(p => p.handle)
+
+        const result = _saveReview(this.currentUser, this.project.name, responses)
+        await expect(result).to.be.rejectedWith(`Reviews cannot be accepted for project ${this.project.name} because a lead coach has not been assigned. The project members have been notified.`)
+        expect(chatService.sendDirectMessage.callCount).to.eql(1)
+        expect(chatService.sendDirectMessage).to.have.been.calledWith(playerHandles, `A review has been blocked for project ${this.project.name}. Please ask the coaching coordinator to assign a lead coach.`)
+      })
+    })
   })
 })
 


### PR DESCRIPTION
Fixes [ch2136](https://app.clubhouse.io/learnersguild/story/2136)

## Overview

Adds handler for when user attempts to review a project that has no lead coach assigned. New behavior: If no coach assigned, error message is sent to reviewer & direct message is sent to the players on the team. 

> A CandleLion Poem
> 
> Turn a candle inside out
> and you've got the smallest
> portion of a lion standing
> there at the edge of the
> shadows.
> 
> -Richard Brautigan