### PR TITLE
add compression package to gzip server responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "bull": "^1.0.0-rc1",
     "cache-manager": "^2.4.0",
     "chokidar": "^1.4.3",
+    "compression": "^1.6.2",
     "config": "^1.21.0",
     "cookie-parser": "^1.4.1",
     "cors": "^2.7.1",

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,7 @@ import {HTTPS as https} from 'express-sslify'
 import bodyParser from 'body-parser'
 import cookieParser from 'cookie-parser'
 import raven from 'raven'
+import compression from 'compression'
 
 import config from 'src/config'
 import configureApp from './configureApp'
@@ -23,6 +24,8 @@ export function start() {
 
   const app = new Express()
   const httpServer = http.createServer(app)
+
+  app.use(compression())
 
   configureApp(app)
 


### PR DESCRIPTION
Fixes [ch2420](https://app.clubhouse.io/learnersguild/story/2420)

## Overview

Use middleware that will automatically compress (gzip) server responses.

## Data Model / DB Schema Changes

None

## Environment / Configuration Changes

None

## Notes
