### PR TITLE
Automatically create projects for non-voting phases

### DIFF
--- a/data/phases.yaml
+++ b/data/phases.yaml
@@ -14,23 +14,30 @@
   number: 1
   hasVoting: false
   hasRetrospective: false
+  practiceGoalNumber: 412
+  interviewGoalNumber: 416
 -
   id: e9548492-6106-4b06-bb54-a42d9479efb1
   number: 2
   hasVoting: false
   hasRetrospective: false
+  practiceGoalNumber: 413
+  interviewGoalNumber: 417
 -
   id: 80c22650-b0e4-4223-a073-fa0004e8785d
   number: 3
   hasVoting: true
   hasRetrospective: true
+  interviewGoalNumber: 418
 -
   id: ab4e7c93-1ce3-4c15-81a4-69f92e23854f
   number: 4
   hasVoting: false
   hasRetrospective: true
+  practiceGoalNumber: 414
 -
   id: 44222a6b-97de-42e8-9e11-f3427e975420
   number: 5
   hasVoting: false
   hasRetrospective: false
+  practiceGoalNumber: 415

--- a/server/services/dataService/models/phase.js
+++ b/server/services/dataService/models/phase.js
@@ -25,6 +25,14 @@ export default function phaseModel(thinky) {
         .allowNull(false)
         .default(false),
 
+      practiceGoalNumber: number() // workaround for the goal service API not having a search feature.
+        .integer()
+        .allowNull(true),
+
+      interviewGoalNumber: number() // workaround for the goal service API not having a search feature.
+        .integer()
+        .allowNull(true),
+
       createdAt: date()
         .allowNull(false)
         .default(r.now()),

--- a/server/workers/cycleLaunched/worker.js
+++ b/server/workers/cycleLaunched/worker.js
@@ -1,35 +1,31 @@
 /* eslint-disable prefer-arrow-callback */
 import Promise from 'bluebird'
 import logger from 'src/server/util/logger'
-import initializeProject from 'src/server/actions/initializeProject'
+import generateProjectName from 'src/server/actions/generateProjectName'
 import sendCycleLaunchAnnouncement from 'src/server/actions/sendCycleLaunchAnnouncement'
 import {formProjectsIfNoneExist} from 'src/server/actions/formProjects'
-import {Moderator} from 'src/server/services/dataService'
+import {getGoalInfo} from 'src/server/services/goalLibraryService'
+import {Moderator, Phase, Player, Project} from 'src/server/services/dataService'
 
 export function start() {
   const jobService = require('src/server/services/jobService')
   jobService.processJobs('cycleLaunched', processCycleLaunched, _handleCycleLaunchError)
 }
 
-export async function processCycleLaunched(cycle, options) {
+export async function processCycleLaunched(cycle) {
   console.log(`Forming teams for cycle ${cycle.cycleNumber} of chapter ${cycle.chapterId}`)
 
+  const nonVotingProjects = await _createProjectsInCycleForNonVotingPhases(cycle)
+  console.log(`${nonVotingProjects.length} project(s) created for all non-voting phases`)
+
   const handlePFAError = err => _notifyModerators(cycle, `⚠️ ${err.message}`)
-  const projects = await formProjectsIfNoneExist(cycle.id, handlePFAError)
-  if (!projects || projects.length === 0) {
-    console.warn(`No new projects formed for cycle ${cycle.cycleNumber}; cycle launch aborted`)
+  const votingProjects = await formProjectsIfNoneExist(cycle.id, handlePFAError)
+  if (!votingProjects || votingProjects.length === 0) {
+    console.warn(`No vote-based projects formed for cycle ${cycle.cycleNumber}; cycle launch aborted`)
     return
   }
 
-  await Promise.each(projects, async project => {
-    try {
-      await initializeProject(project, options)
-    } catch (err) {
-      logger.error(`Error initializing project #${project.name}:`, err)
-    }
-  })
-
-  return sendCycleLaunchAnnouncement(cycle, projects)
+  await sendCycleLaunchAnnouncement(cycle, votingProjects)
     .catch(err => logger.warn(`Failed to send cycle launch announcement for cycle ${cycle.cycleNumber}: ${err}`))
 }
 
@@ -49,4 +45,48 @@ async function _notifyModerators(cycle, message) {
   } catch (err) {
     console.error('Moderator notification error:', err)
   }
+}
+
+async function _createProjectsInCycleForNonVotingPhases(cycle) {
+  console.log('Automatically creating projects for non-voting phases')
+
+  const nonVotingPhases = await Phase.filter({hasVoting: false}).hasFields('practiceGoalNumber')
+  if (nonVotingPhases.length === 0) {
+    console.log('No non-voting phases found; skipped')
+    return []
+  }
+
+  let newPhaseProjects = []
+  await Promise.each(nonVotingPhases, async phase => {
+    const existingProjects = await Project.filter({cycleId: cycle.id, phaseId: phase.id})
+    if (existingProjects.length > 0) {
+      console.log('Existing projects found for non-voting phase; skipped')
+      return
+    }
+
+    const players = await Player.filter({phaseId: phase.id})
+    if (players.length === 0) {
+      console.log(`No players found in Phase ${phase.number}; skipped`)
+      return
+    }
+
+    const goal = await getGoalInfo(phase.practiceGoalNumber)
+
+    const projects = await Promise.map(players, async player => ({
+      name: await generateProjectName(),
+      chapterId: cycle.chapterId,
+      cycleId: cycle.id,
+      phaseId: phase.id,
+      playerIds: [player.id],
+      goal,
+    }), {concurrency: 5})
+
+    const savedProjects = await Project.save(projects)
+
+    console.log(`${savedProjects.length} project(s) automatically created for Phase ${phase.number}`)
+
+    newPhaseProjects = newPhaseProjects.concat(savedProjects)
+  })
+
+  return newPhaseProjects
 }

--- a/test/factories/phase.js
+++ b/test/factories/phase.js
@@ -10,6 +10,8 @@ export default function define(factory) {
     number: factory.sequence(n => n),
     hasVoting: false,
     hasRetrospective: false,
+    practiceGoalNumber: 1,
+    interviewGoalNumber: 1001,
     createdAt: cb => cb(null, now),
     updatedAt: cb => cb(null, now),
   })


### PR DESCRIPTION
Fixes [ch2772](https://app.clubhouse.io/learnersguild/story/2772).

## Overview

- `Project` model: adds fields for goal number refs (a workaround for the jsdev API, which doesn't support search)
- phase YAML config: sets refs to practice and interview goal numbers
- cycleLaunched worker: automatically creates 1-person projects for players in non-voting phases with practice goal numbers set (but skips if existing projects are found to exist in the phase + cycle to prevent dupes in the event of a job retry).
- cycleLaunched worker: removes project initialization calls for PFA-formed projects; the `projectCreated` worker (formerly `projectStarted`) now handles project initialization for all projects inserted to the db

## Data Model / DB Schema Changes

- adds `Phase.practiceGoalNumber`
- adds `Phase.interviewGoalNumber`

## Environment / Configuration Changes

None.