### PR TITLE
Ensure goal channels only created for voting phases

### DIFF
--- a/server/actions/__tests__/initializeProject.test.js
+++ b/server/actions/__tests__/initializeProject.test.js
@@ -102,6 +102,12 @@ describe(testContext(__filename), function () {
         await initializeProject(this.project)
         expect(chatService.sendDirectMessage).to.have.been.calledWithMatch(memberHandles, /You're in Phase/)
       })
+
+      it('should not create a goal channel', async function () {
+        await initializeProject(this.project)
+        expect(chatService.createChannel.callCount).to.eq(0)
+        expect(chatService.inviteToChannel.callCount).to.eq(0)
+      })
     })
   })
 })

--- a/server/actions/initializeProject.js
+++ b/server/actions/initializeProject.js
@@ -31,6 +31,8 @@ export default async function initializeProject(project) {
   const channelName = String(project.goal.number)
   const channelTopic = project.goal.url
 
-  await initializeChannel(channelName, {topic: channelTopic, users: memberHandles})
+  if (phase.hasVoting) {
+    await initializeChannel(channelName, {topic: channelTopic, users: memberHandles})
+  }
   await sendProjectWelcomeMessages(project, {members})
 }


### PR DESCRIPTION
Fixes #906

## Overview

Changes functionality that created goal channels for every project to only create goal channels for projects with users in voting phases.

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.

## Notes

None.
