### PR TITLE
Change UserForm to use react-toolbox/dropdown.

### DIFF
--- a/common/components/UserForm/index.jsx
+++ b/common/components/UserForm/index.jsx
@@ -7,7 +7,7 @@ import Helmet from 'react-helmet'
 import ContentHeader from 'src/common/components/ContentHeader'
 import NotFound from 'src/common/components/NotFound'
 import {Flex} from 'src/common/components/Layout'
-import {FORM_TYPES, renderInput} from 'src/common/util/form'
+import {FORM_TYPES, renderDropdown} from 'src/common/util/form'
 
 import styles from './index.scss'
 
@@ -21,6 +21,8 @@ class UserForm extends Component {
       formType,
       onSave,
       user,
+      phaseSelectOptions,
+      preventOnBlur
     } = this.props
 
     if (formType === FORM_TYPES.NOT_FOUND) {
@@ -44,8 +46,10 @@ class UserForm extends Component {
             icon="trending_up"
             label="Phase Number"
             hint={'e.g. "2"'}
-            component={renderInput}
-            required
+            source={phaseSelectOptions}
+            auto
+            component={renderDropdown}
+            onBlur={preventOnBlur}
             />
           <Flex className={styles.footer} justifyContent="space-between">
             <Button
@@ -70,6 +74,8 @@ UserForm.propTypes = {
   formType: PropTypes.oneOf(Object.values(FORM_TYPES)).isRequired,
   onSave: PropTypes.func.isRequired,
   user: PropTypes.object,
+  phaseSelectOptions: PropTypes.array,
+  preventOnBlur: PropTypes.func,
 }
 
 export default UserForm

--- a/common/containers/UserForm/index.jsx
+++ b/common/containers/UserForm/index.jsx
@@ -4,6 +4,7 @@ import {reduxForm} from 'redux-form'
 
 import {showLoad, hideLoad} from 'src/common/actions/app'
 import {findUsers, updateUser} from 'src/common/actions/user'
+import {findPhases} from 'src/common/actions/phase'
 import {userSchema, asyncValidate} from 'src/common/validations'
 import UserForm from 'src/common/components/UserForm'
 import {findAny} from 'src/common/util'
@@ -45,6 +46,7 @@ UserFormContainer.fetchData = fetchData
 function fetchData(dispatch, props) {
   if (props.params.identifier) {
     dispatch(findUsers([props.params.identifier]))
+    dispatch(findPhases())
   }
 }
 
@@ -56,9 +58,17 @@ function handleSubmit(dispatch) {
 
 function mapStateToProps(state, props) {
   const {identifier} = props.params
-  const {app, users} = state
+  const {app, users, phases} = state
   const user = findAny(users.users, identifier, ['id', 'handle'])
   const phase = (user ? user.phase : null) || {}
+
+  const phaseSelectOptions = Object.keys(phases.phases)
+    .map((key, index) => {
+      return {value: index + 1, label: index + 1}
+    })
+  function preventOnBlur(event) {
+    event.preventDefault()
+  }
 
   let formType = FORM_TYPES.UPDATE
   if (identifier && !user && !users.isBusy) {
@@ -76,6 +86,8 @@ function mapStateToProps(state, props) {
     formType,
     user,
     initialValues,
+    phaseSelectOptions,
+    preventOnBlur,
   }
 }
 

--- a/common/util/form.js
+++ b/common/util/form.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react'
 import DatePicker from 'react-toolbox/lib/date_picker'
 import TimePicker from 'react-toolbox/lib/time_picker'
 import Input from 'react-toolbox/lib/input'
+import Dropdown from 'react-toolbox/lib/dropdown'
 
 /* eslint-disable react/no-unused-prop-types */
 const propTypes = {
@@ -19,6 +20,11 @@ export function renderInput(field) {
   return <Input {..._values(field)}/>
 }
 renderInput.propTypes = propTypes
+
+export function renderDropdown(field) {
+  return <Dropdown {..._values(field)}/>
+}
+renderDropdown.propTypes = propTypes
 
 export function renderDatePicker(field) {
   const {input: {value}} = field


### PR DESCRIPTION
Fixes [910](https://app.clubhouse.io/learnersguild/story/910).

## Overview
Modify UserForm component to use the react-toolbox Dropdown instead of Input. 

#### /src/common/util/form.js
- Added import for Dropdown component.
- Created renderDropdown component.

#### /src/common/containers/UserForm/Index.jsx
- Import findPhases and add to fetchData()
- Pull phases from state
- Declare phaseSelectOptions as an array of objects for Dropdown component.
- Define preventOnBlur function as work-around for [issue](https://github.com/erikras/redux-form/issues/2229) with react-toolbox/dropdown.
- Add phaseSelectOptions and preventOnBlur to the return of mapStateToProps()

#### /src/common/components/UserForm/index.jsx
- Pull phaseSelectOptions and preventOnBlur from props.
- Change component prop to renderDropdown.
- Pass in onBlur prop, preventOnBlur.

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.

## Notes

The issue with react-toolbox/dropdown was not able to be resolved using onBlur={null} as suggested [here](https://github.com/erikras/redux-form/issues/2229) so I had to write a small function that prevents the default action. For some reason onBlur was being run when I would initially click the dropdown menu, then again when I selected an option, then again when clicking out of the dropdown; and this was preventing the user from actually clicking the submit button.
