### PR TITLE
Remove list of project names from slack announcement for cycle launch.

### DIFF
--- a/src/server/actions/sendCycleLaunchAnnouncements.js
+++ b/src/server/actions/sendCycleLaunchAnnouncements.js
@@ -12,19 +12,18 @@ export default async function sendCycleLaunchAnnouncements(cycleId) {
 async function _sendAnnouncementToPhase(cycle, phase) {
   const chatService = require('src/server/services/chatService')
 
-  const projects = await Project.filter({cycleId: cycle.id, phaseId: phase.id}).pluck('name', 'goal')
+  const numOfProjects = await Project.filter({cycleId: cycle.id, phaseId: phase.id}).count()
   try {
-    await chatService.sendChannelMessage(phase.channelName, _buildAnnouncement(cycle, projects))
+    await chatService.sendChannelMessage(phase.channelName, _buildAnnouncement(cycle, numOfProjects))
   } catch (err) {
     console.warn(`Failed to send cycle launch announcement to Phase ${phase.number} for cycle ${cycle.cycleNumber}: ${err}`)
   }
 }
 
-function _buildAnnouncement(cycle, projects) {
+function _buildAnnouncement(cycle, numOfProjects) {
   let announcement = `🚀  *Cycle ${cycle.cycleNumber} has been launched!*\n`
-  if (projects.length > 0) {
-    const projectListString = projects.map(p => `  • #${p.name} - _${p.goal.title}_`).join('\n')
-    announcement += `>The following projects have been created:\n${projectListString}`
+  if (numOfProjects > 0) {
+    announcement += `>${numOfProjects} projects were created.\n`
   } else {
     announcement += '>No projects created'
   }


### PR DESCRIPTION
Fixes #933.

## Overview

#### server/actions/sendCycleLaunchAnnouncements.js

- Changed projects variable to numOfProjects and altered the query to return the count.
- Changed announcement message in _buildAnnouncement to contain a line displaying numOfProjects, rather than the list of project names.

## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

none

## Notes
