### PR TITLE
Member phase change handling updates

### DIFF
--- a/src/common/models/pool.js
+++ b/src/common/models/pool.js
@@ -1,1 +1,15 @@
 export const MAX_POOL_SIZE = 15
+
+export const POOL_NAMES = [
+  'Red',
+  'Orange',
+  'Yellow',
+  'Green',
+  'Blue',
+  'Indigo',
+  'Violet',
+  'Black',
+  'White',
+  'Silver',
+  'Gold',
+]

--- a/src/server/actions/addMemberToPoolInCycle.js
+++ b/src/server/actions/addMemberToPoolInCycle.js
@@ -1,0 +1,31 @@
+import {r, errors, Cycle, Member, Phase, Pool, PoolMember} from 'src/server/services/dataService'
+import {LGBadRequestError, LGInternalServerError} from 'src/server/util/error'
+
+export default async function addMemberToPoolInCycle(cycleId, memberId) {
+  const cycle = typeof cycleId === 'string' ? await Cycle.get(cycleId) : cycleId
+  const member = typeof memberId === 'string' ? await Member.get(memberId).getJoin({phase: true}) : memberId
+  const phase = member.phase || (member.phaseId ? await Phase.get(member.phaseId) : null)
+  if (!phase) {
+    throw new LGBadRequestError(`Member ${member.id} must be assigned to a phase to be added to a pool`)
+  }
+
+  const newestPool = await Pool.filter({cycleId: cycle.id, phaseId: phase.id})
+    .orderBy(r.desc('createdAt'))
+    .nth(0)
+    .default(null)
+    .catch(errors.DocumentNotFound, () => {})
+
+  if (!newestPool) {
+    if (phase.hasVoting === false) {
+      throw new LGBadRequestError(`There are no pools for cycle ${cycle.id} and phase ${phase.id}; phase is not a voting phase`)
+    }
+    throw new LGInternalServerError(`No existing pool found for voting phase ${phase.id} and cycle ${cycle.id}`)
+  }
+
+  return PoolMember.save({
+    poolId: newestPool.id,
+    memberId: member.id,
+  })
+
+  // TODO: if pool is now too big, split
+}

--- a/src/server/actions/createPoolsForCycle.js
+++ b/src/server/actions/createPoolsForCycle.js
@@ -3,21 +3,7 @@ import Promise from 'bluebird'
 import {range, unique, groupById, shuffle} from 'src/common/util'
 import {Pool, PoolMember} from 'src/server/services/dataService'
 import findActiveVotingMembersInChapter from 'src/server/actions/findActiveVotingMembersInChapter'
-import {MAX_POOL_SIZE} from 'src/common/models/pool'
-
-const POOL_NAMES = [
-  'Red',
-  'Orange',
-  'Yellow',
-  'Green',
-  'Blue',
-  'Indigo',
-  'Violet',
-  'Black',
-  'White',
-  'Silver',
-  'Gold',
-]
+import {POOL_NAMES, MAX_POOL_SIZE} from 'src/common/models/pool'
 
 export default async function createPoolsForCycle(cycle) {
   const members = await findActiveVotingMembersInChapter(cycle.chapterId)

--- a/src/server/configureChangeFeeds/index.js
+++ b/src/server/configureChangeFeeds/index.js
@@ -5,6 +5,7 @@ import cycleStateChanged from './cycleStateChanged'
 import projectCreated from './projectCreated'
 import surveySubmitted from './surveySubmitted'
 import voteSubmitted from './voteSubmitted'
+import memberPhaseChanged from './memberPhaseChanged'
 
 export default function configureChangeFeeds() {
   const queueService = require('src/server/services/queueService')
@@ -20,6 +21,7 @@ export default function configureChangeFeeds() {
     projectCreated(queueService.getQueue('projectCreated'))
     surveySubmitted(queueService.getQueue('surveySubmitted'))
     voteSubmitted(queueService.getQueue('voteSubmitted'))
+    memberPhaseChanged(queueService.getQueue('memberPhaseChanged'))
   } catch (err) {
     console.error(`ERROR Configuring Change Feeds: ${err.stack ? err.stack : err}`)
     throw (err)

--- a/src/server/configureChangeFeeds/memberPhaseChanged.js
+++ b/src/server/configureChangeFeeds/memberPhaseChanged.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-console, camelcase */
+import processChangeFeedWithAutoReconnect from 'rethinkdb-changefeed-reconnect'
+
+import {changefeedForMemberPhaseChanged} from 'src/server/services/dataService'
+import {handleConnectionError} from './util'
+
+export default function memberPhaseChanged(memberPhaseChangedQueue) {
+  processChangeFeedWithAutoReconnect(
+    changefeedForMemberPhaseChanged, _getFeedProcessor(memberPhaseChangedQueue), handleConnectionError,
+    {changefeedName: 'phase changed'}
+  )
+}
+
+function _getFeedProcessor(memberPhaseChangedQueue) {
+  return ({old_val, new_val}) => {
+    const jobOpts = {
+      attempts: 3,
+      backoff: {type: 'fixed', delay: 5000},
+    }
+    memberPhaseChangedQueue.add({old_val, new_val}, jobOpts)
+  }
+}

--- a/src/server/services/dataService/models/pool.js
+++ b/src/server/services/dataService/models/pool.js
@@ -13,11 +13,11 @@ export default function poolModel(thinky) {
         .uuid(4)
         .allowNull(false),
 
-      name: string()
-        .allowNull(false),
-
       phaseId: string()
         .uuid(4)
+        .allowNull(false),
+
+      name: string()
         .allowNull(false),
 
       createdAt: date()

--- a/src/server/services/dataService/queries/changefeedForMemberPhaseChanged.js
+++ b/src/server/services/dataService/queries/changefeedForMemberPhaseChanged.js
@@ -1,0 +1,8 @@
+import r from '../r'
+
+export default function changefeedForMemberPhaseChanged() {
+  return r.table('members').changes()
+    .filter(
+      r.row('old_val')('phaseId').ne(r.row('new_val')('phaseId')) // phase id changes
+    )
+}

--- a/src/server/workers/__tests__/memberPhaseChanged.test.js
+++ b/src/server/workers/__tests__/memberPhaseChanged.test.js
@@ -1,0 +1,69 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions, max-nested-callbacks */
+import stubs from 'src/test/stubs'
+import factory from 'src/test/factories'
+import {resetDB, useFixture, mockIdmUsersById} from 'src/test/helpers'
+import {GOAL_SELECTION} from 'src/common/models/cycle'
+import {PoolMember} from 'src/server/services/dataService'
+
+describe(testContext(__filename), function () {
+  beforeEach(resetDB)
+
+  beforeEach(function () {
+    stubs.chatService.enable()
+  })
+
+  afterEach(function () {
+    stubs.chatService.disable()
+  })
+
+  describe('processMemberPhaseChangeCompleted()', function () {
+    const chatService = require('src/server/services/chatService')
+
+    const {processMemberPhaseChangeCompleted} = require('../memberPhaseChanged')
+
+    describe('when a member changes phase', function () {
+      beforeEach('set up member phase data', async function () {
+        const [chapter, phase] = await Promise.all([
+          factory.create('chapter'),
+          factory.create('phase', {number: 3, hasVoting: true}),
+        ])
+        const [cycle, member, phaseOld] = await Promise.all([
+          factory.create('cycle', {chapterId: chapter.id, state: GOAL_SELECTION}),
+          factory.create('member', {chapterId: chapter.id, phaseId: phase.id}),
+          factory.create('phase', {number: phase.number - 1, hasVoting: false}),
+        ])
+        useFixture.nockClean()
+        this.user = (await mockIdmUsersById([member.id]))[0]
+        this.pool = factory.create('pool', {cycleId: cycle.id, phaseId: phase.id})
+        this.chapter = chapter
+        this.cycle = cycle
+        this.phase = phase
+        this.phaseOld = phaseOld
+        this.member = member
+        this.memberOld = Object.assign({}, member, {phaseId: phaseOld.id})
+
+        await processMemberPhaseChangeCompleted({
+          old_val: this.memberOld, // eslint-disable-line camelcase
+          new_val: this.member, // eslint-disable-line camelcase
+        })
+      })
+
+      it('invites the member to the new phase\'s channel', async function () {
+        expect(chatService.inviteToChannel).to.have.been
+          .calledWith(this.phase.channelName, [this.user.handle])
+      })
+
+      it('sends a welcome DM to the member', async function () {
+        expect(chatService.sendDirectMessage).to.have.been
+          .calledWithMatch(this.user.handle, `Welcome to Phase ${this.phase.number}!`)
+      })
+
+      it('adds the member to a voting pool for the phase', async function () {
+        const poolMember = await PoolMember.filter({poolId: this.pool.id, memberId: this.member.id})
+        expect(poolMember).to.be.ok
+      })
+    })
+  })
+})

--- a/src/server/workers/index.js
+++ b/src/server/workers/index.js
@@ -8,6 +8,7 @@ require('./projectCreated').start()
 require('./surveySubmitted').start()
 require('./userCreated').start()
 require('./voteSubmitted').start()
+require('./memberPhaseChanged').start()
 
 // start change feed listeners
 require('src/server/configureChangeFeeds')()

--- a/src/server/workers/memberPhaseChanged.js
+++ b/src/server/workers/memberPhaseChanged.js
@@ -1,0 +1,39 @@
+import getMemberInfo from 'src/server/actions/getMemberInfo'
+import addMemberToPoolInCycle from 'src/server/actions/addMemberToPoolInCycle'
+import {Phase, getLatestCycleForChapter} from 'src/server/services/dataService'
+import {GOAL_SELECTION} from 'src/common/models/cycle'
+
+export function start() {
+  const jobService = require('src/server/services/jobService')
+  jobService.processJobs('memberPhaseChanged', processMemberPhaseChangeCompleted)
+}
+
+export async function processMemberPhaseChangeCompleted({old_val: oldMember, new_val: newMember}) {
+  const chatService = require('src/server/services/chatService')
+
+  const memberInfo = (await getMemberInfo([newMember.id]))[0]
+  const newPhase = await Phase.get(newMember.phaseId)
+
+  // invite the member to the new phase channel and send welcome message
+  await chatService.inviteToChannel(newPhase.channelName, [memberInfo.handle])
+  await chatService.sendDirectMessage(memberInfo.handle, _phaseWelcomeMessage(newPhase))
+
+  // update voting pools if voting is still open for the cycle
+  const currentCycle = await getLatestCycleForChapter(newMember.chapterId)
+  if (currentCycle.state === GOAL_SELECTION) {
+    const oldPhase = await Phase.get(oldMember.phaseId)
+    if (oldPhase.hasVoting === true) {
+      // TODO: remove from voting pool and delete submitted votes (if any)
+    }
+    if (newPhase.hasVoting === true) {
+      const poolMember = await addMemberToPoolInCycle(currentCycle, newMember)
+      console.log(`Member ${poolMember.memberId} added to pool ${poolMember.poolId}`)
+    }
+  }
+}
+
+function _phaseWelcomeMessage(phase) {
+  return `Welcome to Phase ${phase.number}! :partyparrot:
+
+To chat with your fellow phase members, check out the #${phase.channelName} channel.`
+}

--- a/src/test/factories/phase.js
+++ b/src/test/factories/phase.js
@@ -8,6 +8,7 @@ export default function define(factory) {
   factory.define('phase', Phase, {
     id: cb => cb(null, faker.random.uuid()),
     number: factory.sequence(n => n),
+    channelName: factory.sequence(n => `phase-${n}`),
     hasVoting: false,
     hasRetrospective: false,
     practiceGoalNumber: 1,


### PR DESCRIPTION
Fixes #909: Member phase change handling updates 

## Overview

Whenever a member is moved to a different phase they are sent a channel invite as well as a direct message welcoming them. If the member is moved to a phase with voting pools then they are placed in a pool where they can vote on a goal.

- Moved pool name constants to a separate file
- Moved the name key-value pair down to accomodate
- Added a data service that observes changes to the database
- Added a new configuration file to the server to construct the queue for members whose phase is being re-assigned.
- Created a worker that will perform the necessary chat services such as channel invite and direct message that welcomes the member.
- Created test file that tests the new feature.

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.

## Notes
The current state of this feature does not split or merge pools yet based on members getting added or removed.
