### PR TITLE
Add 'Null' to the dropdown options to remove user from any phase

### DIFF
--- a/src/common/containers/UserForm/index.jsx
+++ b/src/common/containers/UserForm/index.jsx
@@ -63,7 +63,7 @@ function mapStateToProps(state, props) {
 
   const sortedPhases = Object.values(phases.phases).sort((p1, p2) => p1.number - p2.number)
   const sortedPhaseOptions = [
-    {value: null, label: 'Null'}, ...sortedPhases.map(phaseToOption)
+    {value: null, label: 'No Phase'}, ...sortedPhases.map(phaseToOption)
   ]
 
   let formType = FORM_TYPES.UPDATE

--- a/src/common/containers/UserForm/index.jsx
+++ b/src/common/containers/UserForm/index.jsx
@@ -62,7 +62,9 @@ function mapStateToProps(state, props) {
   const user = findAny(users.users, identifier, ['id', 'handle'])
 
   const sortedPhases = Object.values(phases.phases).sort((p1, p2) => p1.number - p2.number)
-  const sortedPhaseOptions = sortedPhases.map(phaseToOption)
+  const sortedPhaseOptions = [
+    {value: null, label: 'Null'}, ...sortedPhases.map(phaseToOption)
+  ]
 
   let formType = FORM_TYPES.UPDATE
   if (identifier && !user && !users.isBusy) {

--- a/src/common/validations/user.js
+++ b/src/common/validations/user.js
@@ -1,5 +1,5 @@
 import yup from 'yup'
 
 export const userSchema = yup.object().shape({
-  phaseNumber: yup.number().integer().positive().required().max(5),
+  phaseNumber: yup.number().integer().positive().max(5).nullable(),
 })

--- a/src/server/actions/updateUser.js
+++ b/src/server/actions/updateUser.js
@@ -2,7 +2,7 @@ import {Member, Phase} from 'src/server/services/dataService'
 
 export default async function updateUser(values) {
   const phaseNumber = values.phaseNumber
-  const phase = await Phase.filter({number: phaseNumber}).nth(0)
+  const phase = phaseNumber ? await Phase.filter({number: phaseNumber}).nth(0) : {id: null}
   const member = await Member.get(values.id).update({phaseId: phase.id})
   return member
 }


### PR DESCRIPTION
Fixes #1030 

## Overview

Add the dropdown option 'Null' to remove the user from any phase.

## Data Model / DB Schema Changes

None

## Environment / Configuration Changes

None

## Notes

None
