### PR TITLE
Fixes "unique key" warning for member.handle link

### DIFF
--- a/src/common/containers/ProjectList/index.jsx
+++ b/src/common/containers/ProjectList/index.jsx
@@ -54,7 +54,8 @@ class ProjectListContainer extends Component {
       const projectURL = `/projects/${project.name}`
       const memberHandles = (project.members || []).map(member => {
         const memberURL = `/users/${member.handle}`
-        return <Link key={member.handle} to={memberURL}>{member.handle}</Link>
+        const linkKey = `${project.name}-${member.handle}`
+        return <Link key={linkKey} to={memberURL}>{member.handle}</Link>
       }).reduce((a, b) => [a, ', ', b])
       return {
         memberHandles: <span>{memberHandles}</span>,


### PR DESCRIPTION
Fixes #707 

## Overview

When ProjectList would render, a warning stating that a unique key should be provided appeared. A new key has been implemented using a `key=project name-member handle` format.

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.

## Notes

None.
