### PR TITLE
Add "Week" column to project table #1031 

### DIFF
--- a/src/common/actions/queries/findProjectsForCycle.js
+++ b/src/common/actions/queries/findProjectsForCycle.js
@@ -16,6 +16,7 @@ export default function findProjectsForCycle({cycleNumber} = {}) {
             id
             cycleNumber
             state
+            weekStartedAt
           }
           goal {
             title

--- a/src/common/components/__tests__/ProjectList.test.js
+++ b/src/common/components/__tests__/ProjectList.test.js
@@ -15,10 +15,11 @@ describe(testContext(__filename), function () {
   const tableHeaderName = 'Name'
   const tableHeaderCycle = 'Cycle'
   const projectModel = {
-    name: {type: String},
+    name: {title: 'Name', type: String},
+    state: {title: 'State', type: String},
+    week: {title: 'Week', type: String},
     cycleNumber: {title: 'Cycle', type: String},
     phaseNumber: {title: 'Phase', type: String},
-    state: {title: 'State', type: String},
     goalTitle: {title: 'Goal', type: String},
     hasArtifact: {title: 'Artifact?', type: String},
     memberHandles: {title: 'Members', type: String},
@@ -35,6 +36,7 @@ describe(testContext(__filename), function () {
       projectData.push({
         cycleNumber,
         state,
+        week: '07-26-17',
         name: project.name,
         phaseNumber: phase.number,
         goalTitle: project.goal.title,
@@ -54,7 +56,7 @@ describe(testContext(__filename), function () {
       phaseId: this.phase.id,
       memberIds: this.users.map(u => u.id),
     }, 6)
-    this.getProps = async function (customProps) {
+    this.getProps = function (customProps) {
       const baseProps = {
         projectModel,
         projectData: buildProjectProps({
@@ -69,19 +71,27 @@ describe(testContext(__filename), function () {
   })
 
   describe('rendering', function () {
-    it('should display the provided projects', async function () {
-      const props = await this.getProps()
-      const root = createProjectList(props)
+    it('should display column headings', function () {
+      const root = createProjectList(this.getProps())
+
+      Object.keys(projectModel).map(key => {
+        return expect(root.html()).to.contain(projectModel[key].title)
+      })
+    })
+
+    it('should display the provided projects', function () {
+      const root = createProjectList(this.getProps())
 
       expect(root.html()).to.contain(this.projects[0].name)
       expect(root.html()).to.contain(this.users.map(u => u.handle).join(', '))
+      expect(root.html()).to.contain('07-26-17')
       expect(root.html()).to.contain(this.cycle.state)
       expect(root.html()).to.contain(buttonLabel)
       expect(root.html()).to.contain('<table')
     })
 
-    it('should display \'No projects found.\' if no projects exist', async function () {
-      const props = await this.getProps({projectData: []})
+    it('should display \'No projects found.\' if no projects exist', function () {
+      const props = this.getProps({projectData: []})
       const root = createProjectList(props)
 
       expect(root.html()).to.contain(noProjectsMessage)
@@ -92,9 +102,9 @@ describe(testContext(__filename), function () {
   })
 
   describe('interactions', function () {
-    it('click \'Load More...\' should call the provided callback function', async function () {
+    it('click \'Load More...\' should call the provided callback function', function () {
       let clicked = false
-      const props = await this.getProps({
+      const props = this.getProps({
         onLoadMoreClicked: () => {
           clicked = true
         }

--- a/src/common/containers/ProjectList/index.jsx
+++ b/src/common/containers/ProjectList/index.jsx
@@ -10,14 +10,16 @@ import {findProjectsForCycle} from 'src/common/actions/project'
 import {findUsers} from 'src/common/actions/user'
 import {findPhases} from 'src/common/actions/phase'
 import {userCan} from 'src/common/util'
+import {formatDate} from 'src/common/util/format'
 
 import styles from './index.scss'
 
 const ProjectModel = {
   name: {type: String},
+  state: {title: 'State', type: String},
+  week: {title: 'Week', type: String},
   cycleNumber: {title: 'Cycle', type: String},
   phaseNumber: {title: 'Phase', type: String},
-  state: {title: 'State', type: String},
   goalTitle: {title: 'Goal', type: String},
   hasArtifact: {title: 'Artifact?', type: String},
   memberHandles: {title: 'Members', type: String},
@@ -63,6 +65,7 @@ class ProjectListContainer extends Component {
           <Link to={projectURL}>{project.name}</Link>
         ) : project.name,
         state: cycle.state,
+        week: formatDate(cycle.weekStartedAt),
         goalTitle: (
           <Link to={projectGoal.url} target="_blank">
             {projectGoal.title}

--- a/src/common/util/format.js
+++ b/src/common/util/format.js
@@ -1,3 +1,5 @@
+import moment from 'moment'
+
 import {
   AsYouTypeFormatter,
   PhoneNumberFormat,
@@ -33,4 +35,8 @@ export function phoneNumberAsE164(str, countryCode = 'US') {
   }
   const phoneNumber = phoneUtil.parse(phoneDigits, countryCode)
   return phoneUtil.format(phoneNumber, PhoneNumberFormat.E164)
+}
+
+export function formatDate(date) {
+  return moment(date).format('MM-DD-YY')
 }

--- a/src/server/graphql/resolvers/index.js
+++ b/src/server/graphql/resolvers/index.js
@@ -1,4 +1,5 @@
 import Promise from 'bluebird'
+import moment from 'moment'
 
 import {surveyCompletedBy, surveyLockedFor} from 'src/common/models/survey'
 import findActiveMembersInChapter from 'src/server/actions/findActiveMembersInChapter'
@@ -125,6 +126,10 @@ export async function resolveProjectUserSummaries(projectSummary, args, {rootVal
     const summary = canViewSummary ? await getUserProjectSummary(user, project, projectUserMap, currentUser) : {}
     return {user, ...summary}
   })
+}
+
+export function resolveStartOfWeek(parent) {
+  return parent.weekStartedAt || moment(parent.startTimestamp).startOf('isoweek').toDate()
 }
 
 export async function resolveUser(source, {identifier}, {rootValue: {currentUser}}) {

--- a/src/server/graphql/schemas/Cycle.js
+++ b/src/server/graphql/schemas/Cycle.js
@@ -2,7 +2,7 @@ import {GraphQLNonNull, GraphQLID, GraphQLInt} from 'graphql'
 import {GraphQLObjectType} from 'graphql/type'
 import {GraphQLDateTime} from 'graphql-custom-types'
 
-import {resolveChapter} from 'src/server/graphql/resolvers'
+import {resolveChapter, resolveStartOfWeek} from 'src/server/graphql/resolvers'
 
 export default new GraphQLObjectType({
   name: 'Cycle',
@@ -19,6 +19,7 @@ export default new GraphQLObjectType({
       updatedAt: {type: new GraphQLNonNull(GraphQLDateTime), description: 'The time when the cycle was last updated'},
       state: {type: CycleState, description: 'What state the cycle is currently in'},
       chapter: {type: Chapter, description: 'The chapter', resolve: resolveChapter},
+      weekStartedAt: {type: new GraphQLNonNull(GraphQLDateTime), description: 'The first day of the cycle', resolve: resolveStartOfWeek},
     }
   },
 })


### PR DESCRIPTION
Fixes #1031 

## Overview

Adds 'week' column to the ProjectList table. The 'week' represents the Monday of a cycle (in MM-DD-YY format). Order of the headings was also changed. ProjectList tests were updated to reflect change and were also refactored. Cycle factory changed to represent new data.

## Data Model / DB Schema Changes

GraphQL Cycle schema was changed to include weekStartedAt property. 

## Environment / Configuration Changes

None.

## Notes
