### PR TITLE
Redirects user to login if not authenticated

### DIFF
--- a/src/common/routes/index.jsx
+++ b/src/common/routes/index.jsx
@@ -7,6 +7,7 @@ import {push} from 'react-router-redux'
 
 import {userCan} from 'src/common/util'
 import {authorizationError} from 'src/common/actions/app'
+import {loginURL} from 'src/common/util/auth'
 import App from 'src/common/containers/App'
 import ChapterForm from 'src/common/containers/ChapterForm'
 import ChapterList from 'src/common/containers/ChapterList'
@@ -25,7 +26,7 @@ const userIsAuthenticated = userAuthWrapper({
   authSelector: state => state.auth.currentUser,
   redirectAction: () => {
     if (typeof window !== 'undefined' && window.location) {
-      window.location.href = `${process.env.IDM_BASE_URL}/sign-in?redirect=${encodeURIComponent(window.location.href)}`
+      window.location.href = loginURL({redirect: window.location.href})
     }
     return {type: 'ignore'}
   },

--- a/src/common/util/auth.js
+++ b/src/common/util/auth.js
@@ -1,0 +1,4 @@
+export function loginURL(options = {}) {
+  const redirect = options.redirect ? `?redirect=${encodeURIComponent(options.redirect)}` : ''
+  return `${process.env.IDM_BASE_URL}/sign-in${redirect}`
+}

--- a/src/server/jobQueuesUI.js
+++ b/src/server/jobQueuesUI.js
@@ -5,6 +5,7 @@ import toureiro from 'toureiro'
 import config from 'src/config'
 import {userCan} from 'src/common/util'
 import {LGNotAuthorizedError} from 'src/server/util/error'
+import {loginURL} from 'src/common/util/auth'
 
 const app = new express.Router()
 const redisConfig = url.parse(config.server.redis.url)
@@ -20,8 +21,12 @@ const toureiroApp = toureiro({
 app.use(
   '/job-queues',
   (req, res, next) => {
-    if (!req.user || !userCan(req.user, 'monitorJobQueues')) {
-      throw new LGNotAuthorizedError()
+    if (!req.user) {
+      const redirectUrl = `${req.protocol}://${req.get('host')}${req.originalUrl}`
+      return res.redirect(loginURL({redirect: redirectUrl}))
+    }
+    if (!userCan(req.user, 'monitorJobQueues')) {
+      return next(new LGNotAuthorizedError())
     }
     next()
   },

--- a/src/server/util/error.js
+++ b/src/server/util/error.js
@@ -112,9 +112,11 @@ export class LGCLIUsageError extends LGCLICommandError {
 
 export function formatServerError(error) {
   const parsedError = parseQueryError(error && error.originalError ? error.originalError : error)
-
   if (parsedError instanceof LGError) {
     return parsedError
+  }
+  if (parsedError.name === 'LGNotAuthorizedError') {
+    return new LGNotAuthorizedError(parsedError)
   }
   if (parsedError.name === 'BadRequestError') {
     return new LGBadRequestError(parsedError)


### PR DESCRIPTION
Fixes #981 

## Overview

Redirects the user to login if not authenticated when requesting /job-queues instead of returning a 500 code.

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.

## Notes

Provided redirect back to /job-queues. Returns 401/unauthorized in the browser.