### PR TITLE
Makes user avatars in /users view clickable links to profile pages

### DIFF
--- a/src/common/containers/UserList/index.jsx
+++ b/src/common/containers/UserList/index.jsx
@@ -45,12 +45,14 @@ class UserListContainer extends Component {
       return Object.assign({}, user, {
         avatarUrl: (
           <Flex alignItems_center>
-            <img
-              className={styles.userImage}
-              src={user.avatarUrl}
-              alt={altTitle}
-              title={altTitle}
-              />
+            <Link to={userURL}>
+              <img
+                className={styles.userImage}
+                src={user.avatarUrl}
+                alt={altTitle}
+                title={altTitle}
+                />
+            </Link>
           </Flex>
         ),
         handle: <Link to={userURL}>{user.handle}</Link>,


### PR DESCRIPTION
Fixes #1056 

## Overview

Makes user avatars in /users view clickable links to profile pages

## Data Model / DB Schema Changes

None

## Environment / Configuration Changes

None

## Notes

None
