### PR TITLE
Adds ability to create invitation code for any existing user roles

### DIFF
--- a/src/common/util/userCan.js
+++ b/src/common/util/userCan.js
@@ -47,8 +47,6 @@ const CAPABILITY_ROLES = {
   monitorJobQueues: [ADMIN],
 }
 
-export const ROLES = [...GENERAL_USE]
-
 export default function userCan(currentUser, capability) {
   if (!currentUser) {
     return false

--- a/src/common/util/userCan.js
+++ b/src/common/util/userCan.js
@@ -1,8 +1,10 @@
-import {ADMIN, MEMBER} from 'src/common/models/user'
+import {ADMIN, MEMBER, STAFF, COACH} from 'src/common/models/user'
 
 const GENERAL_USE = [
   ADMIN,
   MEMBER,
+  STAFF,
+  COACH,
 ]
 
 const CAPABILITY_ROLES = {
@@ -45,11 +47,7 @@ const CAPABILITY_ROLES = {
   monitorJobQueues: [ADMIN],
 }
 
-export const VALID_ROLES = Object.keys(CAPABILITY_ROLES).map(capability => {
-  return CAPABILITY_ROLES[capability]
-}).reduce((prev, curr) => {
-  return [...new Set(prev.concat(curr))]
-}, [])
+export const ROLES = [...GENERAL_USE]
 
 export default function userCan(currentUser, capability) {
   if (!currentUser) {

--- a/src/common/validations/inviteCode.js
+++ b/src/common/validations/inviteCode.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-template-curly-in-string */
 import yup from 'yup'
 
-import {ROLES} from 'src/common/util/userCan'
+import {USER_ROLES} from 'src/common/models/user'
 
-const invalidRoleMessage = `\${path} must be one of the following values: ${ROLES.join(', ')}`
+const invalidRoleMessage = `\${path} must be one of the following values: ${USER_ROLES.join(', ')}`
 
 export const inviteCodeSchema = yup.object().shape({
   code: yup.string().required().min(6),
@@ -13,7 +13,7 @@ export const inviteCodeSchema = yup.object().shape({
     invalidRoleMessage,
     function (roles) {
       roles.forEach(role => {
-        if (ROLES.indexOf(role) < 0) {
+        if (USER_ROLES.indexOf(role) < 0) {
           throw this.createError({message: invalidRoleMessage})
         }
       })

--- a/src/common/validations/inviteCode.js
+++ b/src/common/validations/inviteCode.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-template-curly-in-string */
 import yup from 'yup'
 
-import {VALID_ROLES} from 'src/common/util/userCan'
+import {ROLES} from 'src/common/util/userCan'
 
-const invalidRoleMessage = `\${path} must be one of the following values: ${VALID_ROLES.join(', ')}`
+const invalidRoleMessage = `\${path} must be one of the following values: ${ROLES.join(', ')}`
 
 export const inviteCodeSchema = yup.object().shape({
   code: yup.string().required().min(6),
@@ -13,7 +13,7 @@ export const inviteCodeSchema = yup.object().shape({
     invalidRoleMessage,
     function (roles) {
       roles.forEach(role => {
-        if (VALID_ROLES.indexOf(role) < 0) {
+        if (ROLES.indexOf(role) < 0) {
           throw this.createError({message: invalidRoleMessage})
         }
       })


### PR DESCRIPTION
Fixes #986 

## Overview

Provided ROLES to invite code validation so that an admin can create an invite code with any defined roles (from userCan).

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.

## Notes