### PR TITLE
Adds server validation to chapter names

### DIFF
--- a/src/server/actions/__tests__/saveChapter.test.js
+++ b/src/server/actions/__tests__/saveChapter.test.js
@@ -29,6 +29,22 @@ describe(testContext(__filename), function () {
     expect(newChapter.id).to.eq(values.id)
   })
 
+  it('validates that chapter name is unique', async function () {
+    const chapter = await factory.build('chapter')
+    const chapterWithSameName = await factory
+      .build('chapter', {name: chapter.name})
+    await saveChapter(chapter)
+    expect(saveChapter(chapterWithSameName))
+      .to.be.rejectedWith('Chapter name must be unique')
+  })
+
+  it('changes name to lower case and removes white spaces', async function () {
+    const chapter = await factory.build('chapter', {name: 'aBc dEf'})
+    await saveChapter(chapter)
+    const sameChapter = await getChapter(chapter.id)
+    expect(sameChapter.name).to.eq('abcdef')
+  })
+
   it('updates an existing chapter without changing unspecified attrs', async function () {
     const {
       id,

--- a/src/server/actions/__tests__/saveChapter.test.js
+++ b/src/server/actions/__tests__/saveChapter.test.js
@@ -29,20 +29,25 @@ describe(testContext(__filename), function () {
     expect(newChapter.id).to.eq(values.id)
   })
 
-  it('validates that chapter name is unique', async function () {
-    const chapter = await factory.build('chapter')
-    const chapterWithSameName = await factory
-      .build('chapter', {name: chapter.name})
-    await saveChapter(chapter)
+  it('validates that chapter name is unique for new insert', async function () {
+    const chapter = await factory.create('chapter')
+    const chapterWithSameName = await factory.build('chapter', {name: chapter.name})
     expect(saveChapter(chapterWithSameName))
       .to.be.rejectedWith('Chapter name must be unique')
   })
 
-  it('changes name to lower case and removes white spaces', async function () {
+  it('validates that chapter name is unique for update', async function () {
+    const chapter1 = await factory.create('chapter')
+    const chapter2 = await factory.create('chapter')
+    expect(saveChapter({...chapter1, name: chapter2.name}))
+      .to.be.rejectedWith('Chapter name must be unique')
+  })
+
+  it('removes white spaces', async function () {
     const chapter = await factory.build('chapter', {name: 'aBc dEf'})
     await saveChapter(chapter)
     const sameChapter = await getChapter(chapter.id)
-    expect(sameChapter.name).to.eq('abcdef')
+    expect(sameChapter.name).to.eq('aBcdEf')
   })
 
   it('updates an existing chapter without changing unspecified attrs', async function () {

--- a/src/server/actions/saveChapter.js
+++ b/src/server/actions/saveChapter.js
@@ -1,14 +1,25 @@
 import getChapter from 'src/server/actions/getChapter'
 import {Chapter} from 'src/server/services/dataService'
+import {LGBadRequestError} from 'src/server/util/error'
 
-export default async function saveChapter(values) {
-  const {id} = values || {}
+export default async function saveChapter(chapter) {
+  const {id} = chapter || {}
+  chapter.name = chapter.name.toLowerCase().replace(/\s/g, '')
+
+  const chaptersWithSameName = await Chapter.filter(row => {
+    return row('name').downcase().eq(chapter.name)
+  })
+
+  if (chaptersWithSameName.length > 0) {
+    throw new LGBadRequestError('Chapter name must be unique')
+  }
+
   if (id) {
     // {conflict: 'update'} option doesn't work when using .save() to update
     // https://github.com/neumino/thinky/issues/454
     if (await getChapter(id)) {
-      return Chapter.get(id).updateWithTimestamp(values)
+      return Chapter.get(id).updateWithTimestamp(chapter)
     }
   }
-  return Chapter.save(values)
+  return Chapter.save(chapter)
 }

--- a/src/server/graphql/mutations/__tests__/saveChapter.test.js
+++ b/src/server/graphql/mutations/__tests__/saveChapter.test.js
@@ -41,7 +41,7 @@ describe(testContext(__filename), function () {
         channelName,
         timezone,
         inviteCodes,
-      } = await factory.build('chapter')
+      } = await factory.build('chapter', {name: 'justachaptername'})
 
       const result = await this.saveChapter({
         name,


### PR DESCRIPTION
Fixes #987 

## Overview

When creating or updating a new chapter...

- Adds server validation requiring chapter names to be unique
- Removes whitespace from chapter names
- Turns chapter names to lower case

Adds relevant tests

## Data Model / DB Schema Changes

None

## Environment / Configuration Changes

None

## Notes

Modified the mutations' saveChapter test to use a all lowercase no-spaces name.
