### PR TITLE
Remove "level" fields from pools table in database.

### DIFF
--- a/src/data/migrations/20170728095755-removeLevelsFieldsFromPools.js
+++ b/src/data/migrations/20170728095755-removeLevelsFieldsFromPools.js
@@ -1,0 +1,7 @@
+export async function up(r) {
+  return r.table('pools').replace(r.row.without('levels'))
+}
+
+export async function down() {
+  // irreversible; cannot recover data
+}


### PR DESCRIPTION
Fixes #1017.

## Overview

- Add database migration to remove the 'levels' field from the 'pools' table.

## Data Model / DB Schema Changes

- 'Pools' table no longer contains unnecessary field 'levels'.
- Will need to run upwards migration.

## Environment / Configuration Changes

none

## Notes
