### PR TITLE
Convert member role to learner role. Add default phase to new users who are learners.

### DIFF
--- a/src/common/containers/InviteCodeForm/index.jsx
+++ b/src/common/containers/InviteCodeForm/index.jsx
@@ -12,7 +12,7 @@ function transformValidationInput(values) {
 
 function mapStateToProps(state, props) {
   return {
-    initialValues: {chapterId: props.chapterId, roles: 'member'},
+    initialValues: {chapterId: props.chapterId, roles: 'learner'},
     isActive: props.isActive,
     onSave: props.onSave,
     onCancel: props.onCancel,

--- a/src/common/models/user.js
+++ b/src/common/models/user.js
@@ -1,11 +1,11 @@
 export const ADMIN = 'admin'
 export const COACH = 'coach'
-export const MEMBER = 'member'
+export const LEARNER = 'learner'
 export const STAFF = 'staff'
 
 export const USER_ROLES = [
   ADMIN,
   COACH,
-  MEMBER,
+  LEARNER,
   STAFF,
 ]

--- a/src/common/util/__tests__/userCan.test.js
+++ b/src/common/util/__tests__/userCan.test.js
@@ -20,7 +20,7 @@ describe(testContext(__filename), function () {
   })
 
   it('returns false if none of the roles for the user have the given capability', async function () {
-    const user = await factory.build('user', {roles: ['member']})
+    const user = await factory.build('user', {roles: ['learner']})
     expect(userCan(user, 'createCycle')).to.not.be.ok
   })
 

--- a/src/common/util/userCan.js
+++ b/src/common/util/userCan.js
@@ -1,8 +1,8 @@
-import {ADMIN, MEMBER, STAFF, COACH} from 'src/common/models/user'
+import {ADMIN, LEARNER, STAFF, COACH} from 'src/common/models/user'
 
 const GENERAL_USE = [
   ADMIN,
-  MEMBER,
+  LEARNER,
   STAFF,
   COACH,
 ]

--- a/src/server/cliCommand/commands/__tests__/project.test.js
+++ b/src/server/cliCommand/commands/__tests__/project.test.js
@@ -63,7 +63,7 @@ describe(testContext(__filename), function () {
     it('throws an error if the member did not work on the given project', async function () {
       await this.setCurrentCycleAndUserForProject(this.project)
       const inactiveMember = await factory.create('member', {chapterId: this.project.chapterId})
-      const currentUser = await factory.build('user', {id: inactiveMember.id, roles: ['member']})
+      const currentUser = await factory.build('user', {id: inactiveMember.id, roles: ['learner']})
 
       const args = this.commandSpec.parse(['set-artifact', 'invalid-name', this.url])
       expect(this.commandImpl.invoke(args, {user: currentUser})).to.eventually.throw(/No such project.*that name.*that member/i)

--- a/src/server/services/gitHubService/__tests__/addUserToTeam.test.js
+++ b/src/server/services/gitHubService/__tests__/addUserToTeam.test.js
@@ -15,7 +15,7 @@ describe(testContext(__filename), function () {
       const path = `/teams/${teamId}/memberships/${username}`
       const mockResponse = {
         url: `https://api.github.com${path}`,
-        role: 'member',
+        role: 'learner',
         state: 'active',
       }
       nock(config.server.github.baseURL)

--- a/src/server/workers/__tests__/userCreated.test.js
+++ b/src/server/workers/__tests__/userCreated.test.js
@@ -5,8 +5,9 @@
 import factory from 'src/test/factories'
 import {resetDB} from 'src/test/helpers'
 import {gitHubService} from 'src/test/stubs'
-import {Member} from 'src/server/services/dataService'
+import {Member, Chapter} from 'src/server/services/dataService'
 import {processUserCreated} from 'src/server/workers/userCreated'
+import {addUserToTeam} from 'src/server/services/gitHubService'
 
 describe(testContext(__filename), function () {
   beforeEach(resetDB)
@@ -35,10 +36,12 @@ describe(testContext(__filename), function () {
         it('initializes the member', async function () {
           await processUserCreated(this.user)
           const member = await Member.get(this.user.id)
+          const chapter = (await Chapter.getAll(this.user.inviteCode, {index: 'inviteCodes'}))[0]
 
           expect(member).to.exist
           expect(member.chapterId).to.eq(this.chapter.id, 'member should have chapter ID for invite code')
-          // TODO: fix - should assert github service function called w/ correct args
+          expect(addUserToTeam.callCount).to.eql(1)
+          expect(addUserToTeam.calledWithExactly(this.user.handle, chapter.githubTeamId)).to.eql(true)
         })
 
         describe('if the new user has role of \'learner\'', function () {

--- a/src/server/workers/userCreated.js
+++ b/src/server/workers/userCreated.js
@@ -1,7 +1,9 @@
 import config from 'src/config'
-import {addUserToTeam} from 'src/server/services/gitHubService'
 import {logRejection} from 'src/server/util'
-import {Chapter, Member} from 'src/server/services/dataService'
+import {Chapter, Member, Phase} from 'src/server/services/dataService'
+import {LEARNER} from 'src/common/models/user'
+
+const DEFAULT_PHASE_NUMBER = 1
 
 export function start() {
   const jobService = require('src/server/services/jobService')
@@ -21,10 +23,21 @@ export async function processUserCreated(idmUser) {
 
     const chapter = chapters[0]
 
-    await Member.upsert({
+    const newMember = {
       id: idmUser.id,
       chapterId: chapter.id,
-    })
+    }
+
+    if (idmUser.roles.includes(LEARNER)) {
+      const defaultPhase = (await Phase.getAll(DEFAULT_PHASE_NUMBER, {index: 'number'}))[0]
+      if (!defaultPhase) {
+        throw new Error('Phase not found for default numberL', DEFAULT_PHASE_NUMBER)
+      }
+
+      newMember.phaseId = defaultPhase.id
+    }
+
+    await Member.upsert(newMember)
 
     try {
       await _addUserToChapterGitHubTeam(idmUser.handle, chapter.githubTeamId)
@@ -51,6 +64,7 @@ function _notifyCRMSystemOfMemberSignUp(idmUser) {
 }
 
 async function _addUserToChapterGitHubTeam(userHandle, githubTeamId) {
+  const {addUserToTeam} = require('src/server/services/gitHubService')
   console.log(`Adding ${userHandle} to GitHub team ${githubTeamId}`)
   return logRejection(addUserToTeam(userHandle, githubTeamId), 'Error while adding user to chapter GitHub team.')
 }

--- a/src/server/workers/userCreated.js
+++ b/src/server/workers/userCreated.js
@@ -31,7 +31,7 @@ export async function processUserCreated(idmUser) {
     if (idmUser.roles.includes(LEARNER)) {
       const defaultPhase = (await Phase.getAll(DEFAULT_PHASE_NUMBER, {index: 'number'}))[0]
       if (!defaultPhase) {
-        throw new Error('Phase not found for default numberL', DEFAULT_PHASE_NUMBER)
+        throw new Error('Phase not found for default number', DEFAULT_PHASE_NUMBER)
       }
 
       newMember.phaseId = defaultPhase.id

--- a/src/test/factories/user.js
+++ b/src/test/factories/user.js
@@ -16,7 +16,7 @@ export default function define(factory) {
     dateOfBirth: cb => cb(null, faker.date.past(21).toISOString().slice(0, 10)),
     timezone: cb => cb(null, faker.random.arrayElement(VALID_TIMEZONES)),
     active: true,
-    roles: ['member'],
+    roles: ['learner'],
     inviteCode: 'test',
     authProviders: {},
     createdAt: cb => cb(null, now),


### PR DESCRIPTION
Fixes #1079, #1080 

## Overview

Converted roles where 'member' existed and replaced it with 'learner'. Added default phase when creating a new user who has the learner role in userCreated worker.

## Data Model / DB Schema Changes

User model roles changed from 'member' to 'learner'.

## Environment / Configuration Changes

None. 

## Notes
