### PR TITLE
1084 add row count to tables

### DIFF
--- a/src/common/components/ContentTable/index.jsx
+++ b/src/common/components/ContentTable/index.jsx
@@ -6,15 +6,21 @@ import themeSelect from './themeSelect.scss'
 
 export default class ContentTable extends Component {
   render() {
-    const {allowSelect, onSelectRow} = this.props
+    const {allowSelect, onSelectRow, source, model} = this.props
+    const firstColumnName = Object.keys(model)[0]
+    const numberOfRows = source.length === 1 ? (<b>{source.length} row</b>) : (<b>{source.length} rows</b>)
+    const displaySource = source.concat({[firstColumnName]: numberOfRows})
     return (
-      <Table
-        {...this.props}
-        theme={allowSelect ? themeSelect : theme}
-        onRowClick={allowSelect ? onSelectRow : null}
-        selectable={false}
-        multiSelectable={false}
-        />
+      <div>
+        <Table
+          {...this.props}
+          source={displaySource}
+          theme={allowSelect ? themeSelect : theme}
+          onRowClick={allowSelect ? onSelectRow : null}
+          selectable={false}
+          multiSelectable={false}
+          />
+      </div>
     )
   }
 }
@@ -22,4 +28,6 @@ export default class ContentTable extends Component {
 ContentTable.propTypes = {
   allowSelect: PropTypes.bool,
   onSelectRow: PropTypes.func,
+  source: PropTypes.array.isRequired,
+  model: PropTypes.object.isRequired,
 }

--- a/src/common/components/__tests__/UserList.test.js
+++ b/src/common/components/__tests__/UserList.test.js
@@ -45,8 +45,9 @@ describe(testContext(__filename), function () {
       const props = this.getProps()
       const root = mount(React.createElement(UserList, props))
       const userRows = root.find('TableRow')
+      const numberOfAddedRows = 1
 
-      expect(userRows.length).to.equal(props.userData.length)
+      expect(userRows.length - numberOfAddedRows).to.equal(props.userData.length)
     })
   })
 })


### PR DESCRIPTION
Fixes #1084 

## Overview

Updates ContentTable component to display total number of rows in a table at the foot of it.
Displays `1 row` if singular, otherwise will display `[N] rows`
Updates userList test to account for row appended to table

## Data Model / DB Schema Changes

None

## Environment / Configuration Changes

None

## Notes

None
