### PR TITLE
adds full name to title of user details pages

### DIFF
--- a/src/common/components/UserDetail/index.jsx
+++ b/src/common/components/UserDetail/index.jsx
@@ -181,7 +181,7 @@ class UserDetail extends Component {
     return (
       <Flex className={styles.userDetail}>
         <Helmet>
-          <title>{this.props.user.handle}</title>
+          <title>{this.props.user.handle} ({this.props.user.name})</title>
         </Helmet>
         <Flex>
           {this.renderSidebar()}


### PR DESCRIPTION
Fixes #1088 

## Overview

displays user's full name in parentheses in the title of user's detail page

## Data Model / DB Schema Changes

none

## Environment / Configuration Changes

none

## Notes

none
