### PR TITLE
Changes userCreate to hard-fail if already exists

### DIFF
--- a/src/server/workers/__tests__/userCreated.test.js
+++ b/src/server/workers/__tests__/userCreated.test.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-/* global expect, assert, testContext */
+/* global expect, testContext */
 /* eslint-disable prefer-arrow-callback, no-unused-expressions, max-nested-callbacks */
 
 import factory from 'src/test/factories'
@@ -65,18 +65,14 @@ describe(testContext(__filename), function () {
       })
 
       describe('for an existing member', function () {
-        it('does not replace the given member', async function () {
+        it('fails hard if member already exists', async function () {
           await processUserCreated(this.user)
-          const oldMember = await Member.get(this.user.id)
 
-          assert.doesNotThrow(async function () {
+          const getRejection = async () => {
             await processUserCreated(this.user)
-          }, Error)
+          }
 
-          await processUserCreated({...this.user, name: 'new name'})
-          const updatedUser = await Member.get(this.user.id)
-
-          expect(updatedUser.createdAt).to.eql(oldMember.createdAt)
+          return expect(getRejection()).to.be.rejectedWith(/already exists/i)
         })
       })
     })

--- a/src/server/workers/userCreated.js
+++ b/src/server/workers/userCreated.js
@@ -37,7 +37,12 @@ export async function processUserCreated(idmUser) {
       newMember.phaseId = defaultPhase.id
     }
 
-    await Member.upsert(newMember)
+    const matchingMember = await Member.filter({id: idmUser.id})
+    if (matchingMember && matchingMember.length > 0) {
+      throw new Error('IDM user already exists as member of echo.')
+    }
+
+    await Member.insert(newMember)
 
     try {
       await _addUserToChapterGitHubTeam(idmUser.handle, chapter.githubTeamId)


### PR DESCRIPTION
Fixes #1090 

## Overview

In echo's userCreate worker we were upserting idm users to echo members. Now we have added check that idm user isn't already a member of echo upon insertion. We remove a unit test that checked userCreate was not failing when updating, and replaced it with a unit test that ensures it _does_ fail when adding a member who already exists (i.e. remove update functionality)

## Data Model / DB Schema Changes

None - isolated to worker functionality

## Environment / Configuration Changes

None

## Notes

1. Remaining concerns: Should we only fail-hard when the member who's being added already has chapter information and not just _always_ fail? Without end-to-end testing, was anything dependent up on the upsert functionality - updating echo members using a create? (hopefully not that feels unintuitive)  
1. According to https://www.rethinkdb.com/api/javascript/insert/ we shouldn't have to make a resource expensive data call to Members to check if member already exists, and `insert` default functionality has `{conflict: "error"}` as it's default setting - therefore inserting should error out on it's own. It doesn't though. Is this because we don't have primary keys that indicate to Thinky that we're creating a conflicting id? Console logging indicates that it simply inserts twice without error even when not using upsert.
1. Why does `await Member.filter({id: idmUser.id})` work but `await Member.get(idmUser.id)` not work?

