### PR TITLE
Watch & reload files for worker processes

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -2,6 +2,7 @@
 module.exports = {
   server: {
     secure: false,
+    hotReload: true,
     port: process.env.PORT || '9005',
     baseURL: process.env.APP_BASE_URL,
     sentryDSN: process.env.SENTRY_SERVER_DSN,

--- a/src/config/production.js
+++ b/src/config/production.js
@@ -1,6 +1,7 @@
 module.exports = {
   server: {
     secure: true,
+    hotReload: false,
     rethinkdb: {
       tableCreation: {
         replicas: 3,

--- a/src/server/configureApp.js
+++ b/src/server/configureApp.js
@@ -1,10 +1,7 @@
-import path from 'path'
-
 import config from 'src/config'
 
 export default function configureApp(app) {
   if (config.app.hotReload) {
-    const chokidar = require('chokidar')
     const webpack = require('webpack')
     const webpackDevMiddleware = require('webpack-dev-middleware')
     const webpackHotMiddleware = require('webpack-hot-middleware')
@@ -18,20 +15,6 @@ export default function configureApp(app) {
     }))
 
     app.use(webpackHotMiddleware(compiler))
-
-    // "hot-reload" (flush require cache) server code when it changes
-    const cwd = path.resolve(__dirname, '..')
-    const watcher = chokidar.watch(['client', 'common', 'db', 'server'], {cwd})
-    watcher.on('ready', () => {
-      watcher.on('all', (operation, path) => {
-        console.log(`${operation} ${path} -- clearing  module cache from server`)
-        Object.keys(require.cache).forEach(id => {
-          if (/[/\\]server[/\\]/.test(id)) {
-            delete require.cache[id]
-          }
-        })
-      })
-    })
 
     // "hot-reload" (flush require cache) if webpack rebuilds
     compiler.plugin('done', () => {

--- a/src/server/configureWatcher.js
+++ b/src/server/configureWatcher.js
@@ -1,0 +1,23 @@
+import path from 'path'
+
+import config from 'src/config'
+
+export default function configureWatcher() {
+  if (config.server.hotReload) {
+    const chokidar = require('chokidar')
+
+    // flush require cache for server code when it changes
+    const cwd = path.resolve(__dirname, '..')
+    const watcher = chokidar.watch(['client', 'common', 'data', 'server'], {cwd})
+    watcher.on('ready', () => {
+      watcher.on('all', (operation, path) => {
+        console.log(`${operation} ${path} -- clearing module cache from server`)
+        Object.keys(require.cache).forEach(id => {
+          if (/[/\\]server[/\\]/.test(id)) {
+            delete require.cache[id]
+          }
+        })
+      })
+    })
+  }
+}

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -11,6 +11,7 @@ import compression from 'compression'
 
 import config from 'src/config'
 import configureApp from './configureApp'
+import configureWatcher from './configureWatcher'
 import configureSocketCluster from './configureSocketCluster'
 
 import {default as renderApp} from './render'
@@ -28,6 +29,7 @@ export function start() {
   app.use(compression())
 
   configureApp(app)
+  configureWatcher()
 
   // parse cookies and forms
   app.use(cookieParser())

--- a/src/server/workers/cycleLaunched/index.js
+++ b/src/server/workers/cycleLaunched/index.js
@@ -1,1 +1,4 @@
 require('./worker').start()
+
+// file watch & reload
+require('src/server/configureWatcher')()

--- a/src/server/workers/index.js
+++ b/src/server/workers/index.js
@@ -12,3 +12,6 @@ require('./memberPhaseChanged').start()
 
 // start change feed listeners
 require('src/server/configureChangeFeeds')()
+
+// file watch & reload
+require('src/server/configureWatcher')()


### PR DESCRIPTION
Fixes #1091.

## Overview

The web service app was set up to have files watched and reloaded when changed (via module cache flushing), but the worker apps/processes were not. This change adds file watch & reload for workers, too.

## Data Model / DB Schema Changes

None.

## Environment / Configuration Changes

None.