### PR TITLE
disable voting, automatic project creation, and retrospectives

### DIFF
--- a/src/data/migrations/20170922130030-syncModelData.js
+++ b/src/data/migrations/20170922130030-syncModelData.js
@@ -1,0 +1,8 @@
+export function up() {
+  const reloadDefaultModelData = require('src/server/actions/reloadDefaultModelData')
+  return reloadDefaultModelData()
+}
+
+export function down() {
+  // irreversible; data from dropped table not recoverable
+}

--- a/src/data/phases.yaml
+++ b/src/data/phases.yaml
@@ -15,7 +15,7 @@
   channelName: phase-1
   hasVoting: false
   hasRetrospective: false
-  practiceGoalNumber: 412
+  practiceGoalNumber: null
   interviewGoalNumber: 416
 -
   id: e9548492-6106-4b06-bb54-a42d9479efb1
@@ -23,26 +23,29 @@
   channelName: phase-2
   hasVoting: false
   hasRetrospective: false
-  practiceGoalNumber: 413
+  practiceGoalNumber: null
   interviewGoalNumber: 417
 -
   id: 80c22650-b0e4-4223-a073-fa0004e8785d
   number: 3
   channelName: phase-3
-  hasVoting: true
-  hasRetrospective: true
+  hasVoting: false
+  hasRetrospective: false
+  practiceGoalNumber: null
   interviewGoalNumber: 418
 -
   id: ab4e7c93-1ce3-4c15-81a4-69f92e23854f
   number: 4
   channelName: phase-4
   hasVoting: false
-  hasRetrospective: true
-  practiceGoalNumber: 414
+  hasRetrospective: false
+  practiceGoalNumber: null
+  interviewGoalNumber: null
 -
   id: 44222a6b-97de-42e8-9e11-f3427e975420
   number: 5
   channelName: phase-5
   hasVoting: false
   hasRetrospective: false
-  practiceGoalNumber: 415
+  practiceGoalNumber: null
+  interviewGoalNumber: null

--- a/src/server/graphql/resolvers/__tests__/resolveWeekStartedAt.test.js
+++ b/src/server/graphql/resolvers/__tests__/resolveWeekStartedAt.test.js
@@ -73,17 +73,22 @@ describe(testContext(__filename), function () {
 
   describe('when parent `createdAt` is a Tuesday and has no `startTimestamp`', function () {
     it('should return the date of Monday of same week', function () {
-      const parent = {createdAt: new Date()}
+      const parent = {createdAt: new Date(2017, 8, 19)}
       const result = resolveWeekStartedAt(parent)
       _expectDateEqualToSameMonday(parent.createdAt, result)
     })
   })
 
   describe('when parent has neither `startTimestamp` nor `createdAt`', function () {
-    it('should return the date of Monday of current week', function () {
+    it('should follow rules for current day of the week', function () {
       const parent = {}
       const result = resolveWeekStartedAt(parent)
-      _expectDateEqualToCurrentMonday(result)
+      const currentDay = moment()
+      if (currentDay.isoWeekday() < 4) { // mon - thu
+        _expectDateEqualToCurrentMonday(result)
+      } else {
+        _expectDateEqualToFollowingMonday(currentDay, result)
+      }
     })
   })
 })

--- a/src/server/workers/cycleLaunched/__tests__/worker.test.js
+++ b/src/server/workers/cycleLaunched/__tests__/worker.test.js
@@ -24,7 +24,7 @@ describe(testContext(__filename), function () {
 
       it('automatically creates single-member projects for users in non-voting phases', async function () {
         const practiceGoalNumber = 1
-        const phase = await factory.create('phase', {number: 1, practiceGoalNumber})
+        const phase = await factory.create('phase', {number: 100, practiceGoalNumber})
         const phaseMembers = await factory.createMany('member', {chapterId: this.chapter.id, phaseId: phase.id}, 2)
 
         useFixture.nockClean()

--- a/src/server/workers/cycleLaunched/worker.js
+++ b/src/server/workers/cycleLaunched/worker.js
@@ -4,7 +4,7 @@ import generateProjectName from 'src/server/actions/generateProjectName'
 import sendCycleLaunchAnnouncements from 'src/server/actions/sendCycleLaunchAnnouncements'
 import {formProjectsIfNoneExist} from 'src/server/actions/formProjects'
 import {getGoalInfo} from 'src/server/services/goalLibraryService'
-import {Phase, Member, Project} from 'src/server/services/dataService'
+import {r, Phase, Member, Project} from 'src/server/services/dataService'
 
 export function start() {
   const jobService = require('src/server/services/jobService')
@@ -30,7 +30,10 @@ export async function processCycleLaunched(cycle) {
 async function _createProjectsInCycleForNonVotingPhases(cycle) {
   console.log('Automatically creating projects for non-voting phases')
 
-  const nonVotingPhases = await Phase.filter({hasVoting: false}).hasFields('practiceGoalNumber')
+  const nonVotingPhases = await Phase.filter(row => r.and(
+    row('hasVoting').eq(false),
+    row('practiceGoalNumber').default(null).eq(null).not(),
+  ))
   if (nonVotingPhases.length === 0) {
     console.log('No non-voting phases found; skipped')
     return []


### PR DESCRIPTION
Fixes #1103.

## Overview
For all phases, disables:
- voting
- auto-project creation
- retrospective survey creation

## Data Model / DB Schema Changes

- syncs default model data w/ db

## Environment / Configuration Changes

N/A